### PR TITLE
[260107] feat: 전문 검색 기능 구현 (PostgreSQL) #23

### DIFF
--- a/src/main/java/kr/eolmago/domain/entity/search/SearchKeyword.java
+++ b/src/main/java/kr/eolmago/domain/entity/search/SearchKeyword.java
@@ -63,6 +63,11 @@ public class SearchKeyword extends CreatedAtEntity {
     @Column(name = "last_searched_at", nullable = false)
     private OffsetDateTime lastSearchedAt;
 
+    // 초성 컬럼 (Generated Column)
+    @Column(name = "keyword_chosung", insertable = false, updatable = false)
+    private String keywordChosung;  // 읽기 전용
+
+
     public static SearchKeyword create(String keyword) {
         SearchKeyword searchKeyword = new SearchKeyword();
         searchKeyword.keyword = keyword;

--- a/src/main/java/kr/eolmago/dto/api/auction/response/AuctionSearchResponse.java
+++ b/src/main/java/kr/eolmago/dto/api/auction/response/AuctionSearchResponse.java
@@ -1,0 +1,26 @@
+package kr.eolmago.dto.api.auction.response;
+
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 경매 검색 결과 응답 DTO
+ *  - AuctionListResponse와 동일한 구조이나 검색 특화 필드로 명시하기 위해 생성함.
+ */
+public record AuctionSearchResponse(
+        UUID auctionId,         // 경매 ID
+        Long auctionItemId,     // 경매 아이템 ID
+        String title,           // 경매 제목
+        String thumbnailUrl,    // 썸네일 이미지 URL
+        String sellerNickname,  // 판매자 닉네임
+        Integer currentPrice,   // 현재 가격 (입찰가)
+        int bidCount,           // 입찰 횟수
+        int viewCount,          // 조회수
+        int favoriteCount,      // 찜 개수
+        OffsetDateTime endAt,   // 경매 종료 시간
+        String remainingTime,   // 남은 시간 (포맷팅)
+        AuctionStatus status    // 경매 상태
+) {
+}

--- a/src/main/java/kr/eolmago/global/util/ChosungUtils.java
+++ b/src/main/java/kr/eolmago/global/util/ChosungUtils.java
@@ -1,0 +1,163 @@
+package kr.eolmago.global.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * 한글 초성 관련 유틸리티
+ *  - 초성 여부 판단
+ *  - 한글 여부 판단
+ *  - 검색어 타입 분석
+ *
+ * 사용처:
+ * - AuctionSearchService (검색 타입 판단)
+ * - SearchKeywordService (자동완성)
+ * - Repository (쿼리 분기)
+ *
+ * 설계 원칙:
+ * - 모든 초성 관련 로직을 한 곳에 집중
+ * - 중복 코드 제거
+ * - static 메서드로 유틸리티 제공
+ */
+public class ChosungUtils {
+
+    /**
+     * 초성 문자 범위
+     * - 유니코드: 12593(ㄱ) ~ 12622(ㅎ)
+     * - 총 19개: ㄱ ㄲ ㄴ ㄷ ㄸ ㄹ ㅁ ㅂ ㅃ ㅅ ㅆ ㅇ ㅈ ㅉ ㅊ ㅋ ㅌ ㅍ ㅎ
+     */
+    private static final int CHOSUNG_START = 0x3131; // 12593 (ㄱ)
+    private static final int CHOSUNG_END = 0x314E;   // 12622 (ㅎ)
+
+    /**
+     * 완성형 한글 범위
+     * - 유니코드: 44032(가) ~ 55203(힣)
+     */
+    private static final int HANGUL_START = 0xAC00; // 44032 (가)
+    private static final int HANGUL_END = 0xD7A3;   // 55203 (힣)
+
+    /**
+     * 초성만으로 이루어진 문자열 패턴
+     * - ㄱ-ㅎ 범위만 매칭
+     * - 숫자, 영문, 공백 포함 시 false
+     */
+    private static final Pattern CHOSUNG_ONLY_PATTERN = Pattern.compile("^[ㄱ-ㅎ]+$");
+
+    /**
+     * 초성 포함 문자열 패턴 (부분 매칭)
+     * - 초성이 하나라도 포함되어 있으면 true
+     */
+    private static final Pattern CONTAINS_CHOSUNG_PATTERN = Pattern.compile("[ㄱ-ㅎ]");
+
+    /**
+     * 완성형 한글 포함 여부 패턴
+     * - 가-힣 범위 매칭
+     */
+    private static final Pattern CONTAINS_HANGUL_PATTERN = Pattern.compile("[가-힣]");
+
+    /**
+     * 초성만으로 이루어진 문자열인지 판단
+     *
+     * @param text 검사할 문자열
+     * @return 초성만 있으면 true, 그 외 false
+     */
+    public static boolean isChosungOnly(String text) {
+        if (text == null || text.isEmpty()) {
+            return false;
+        }
+        return CHOSUNG_ONLY_PATTERN.matcher(text).matches();
+    }
+
+    /**
+     * 초성이 포함된 문자열인지 판단
+     *
+     * 차이점:
+     * - isChosungOnly(): 초성"만" 있는지
+     * - containsChosung(): 초성이 "하나라도" 있는지
+     *
+     * 사용 예시:
+     * ChosungUtils.containsChosung("ㅇㅍ")      // true
+     * ChosungUtils.containsChosung("ㅇㅍ14")    // true (초성 + 숫자)
+     * ChosungUtils.containsChosung("아이ㅍ")    // true (한글 + 초성)
+     * ChosungUtils.containsChosung("아이폰")    // false
+     * ChosungUtils.containsChosung("iPhone")   // false
+     *
+     * @param text 검사할 문자열
+     * @return 초성이 하나라도 포함되면 true
+     */
+    public static boolean containsChosung(String text) {
+        if (text == null || text.isEmpty()) {
+            return false;
+        }
+        return CONTAINS_CHOSUNG_PATTERN.matcher(text).find();
+    }
+
+    /**
+     * 완성형 한글이 포함된 문자열인지 판단
+     *
+     * ex)
+     * ChosungUtils.containsHangul("아이폰14")   // true
+     * ChosungUtils.containsHangul("ㅇㅍ")       // false (초성만)
+     *
+     * @param text 검사할 문자열
+     * @return 완성형 한글이 포함되면 true
+     */
+    public static boolean containsHangul(String text) {
+        if (text == null || text.isEmpty()) {
+            return false;
+        }
+        return CONTAINS_HANGUL_PATTERN.matcher(text).find();
+    }
+
+    /**
+     * 문자가 초성인지 판단
+     *
+     * @param c 검사할 문자
+     * @return 초성이면 true
+     */
+    public static boolean isChosungChar(char c) {
+        return c >= CHOSUNG_START && c <= CHOSUNG_END;
+    }
+
+    /**
+     * 문자가 완성형 한글인지 판단
+     *
+     * @param c 검사할 문자
+     * @return 완성형 한글이면 true
+     */
+    public static boolean isHangulChar(char c) {
+        return c >= HANGUL_START && c <= HANGUL_END;
+    }
+
+    /**
+     * 검색어 타입 판단
+     *
+     * 반환값:
+     * - "CHOSUNG": 초성만 (예: "ㅇㅍ")
+     * - "HANGUL": 한글 포함 (예: "아이폰", "갤럭시S24")
+     * - "MIXED": 초성 + 한글 혼합 (예: "ㅇㅍ폰")
+     * - "OTHER": 영문/숫자만 (예: "iPhone", "14")
+     *
+     * @param text 검사할 문자열
+     * @return 키워드 타입 ("CHOSUNG", "HANGUL", "MIXED", "OTHER")
+     */
+    public static String getKeywordType(String text) {
+        if (text == null || text.isEmpty()) {
+            return "OTHER";
+        }
+
+        boolean hasChosung = containsChosung(text);
+        boolean hasHangul = containsHangul(text);
+
+        if (hasChosung && !hasHangul) {
+            return "CHOSUNG";  // 초성만
+        } else if (!hasChosung && hasHangul) {
+            return "HANGUL";   // 한글만 (또는 한글 + 영문/숫자)
+        } else if (hasChosung && hasHangul) {
+            return "MIXED";    // 초성 + 한글 혼합
+        } else {
+            return "OTHER";    // 영문/숫자만
+        }
+    }
+
+
+}

--- a/src/main/java/kr/eolmago/repository/auction/AuctionSearchRepository.java
+++ b/src/main/java/kr/eolmago/repository/auction/AuctionSearchRepository.java
@@ -1,0 +1,10 @@
+package kr.eolmago.repository.auction;
+
+import kr.eolmago.domain.entity.auction.Auction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AuctionSearchRepository extends JpaRepository<Auction, UUID>, AuctionSearchRepositoryCustom {
+
+}

--- a/src/main/java/kr/eolmago/repository/auction/AuctionSearchRepositoryCustom.java
+++ b/src/main/java/kr/eolmago/repository/auction/AuctionSearchRepositoryCustom.java
@@ -1,0 +1,41 @@
+package kr.eolmago.repository.auction;
+
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.dto.api.auction.response.AuctionListDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+/**
+ * Auction 검색 전용 커스텀 Repository 인터페이스
+ *
+ * 특수문자 포함으로 Native Query 사용:
+ * - PostgreSQL 함수 (to_tsvector, similarity, extract_chosung)
+ * - QueryDSL 대신 @Query 사용
+ *
+ * 구현체:
+ * - AuctionSearchRepositoryImpl
+ */
+public interface AuctionSearchRepositoryCustom {
+
+    /**
+     * Full-Text Search (PostgreSQL to_tsvector)
+     */
+    Page<AuctionListDto> searchByFullText(String keyword, AuctionStatus status, Pageable pageable);
+
+    /**
+     * Trigram Similarity (PostgreSQL pg_trgm)
+     */
+    Page<AuctionListDto> searchByTrigram(String keyword, double threshold, AuctionStatus status, Pageable pageable);
+
+    /**
+     * 초성 검색 (extract_chosung 함수)
+     */
+    Page<AuctionListDto> searchByChosung(String chosungKeyword, AuctionStatus status, Pageable pageable);
+
+    /**
+     * 추천 키워드 조회
+     */
+    List<String> getSuggestedKeywords();
+}

--- a/src/main/java/kr/eolmago/repository/auction/impl/AuctionSearchRepositoryCustomImpl.java
+++ b/src/main/java/kr/eolmago/repository/auction/impl/AuctionSearchRepositoryCustomImpl.java
@@ -1,0 +1,334 @@
+package kr.eolmago.repository.auction.impl;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.dto.api.auction.response.AuctionListDto;
+import kr.eolmago.repository.auction.AuctionSearchRepositoryCustom;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Auction 검색 커스텀 Repository 구현체
+ *
+ * 역할:
+ * - Native Query 기반 복잡한 검색 쿼리 구현
+ * - PostgreSQL 함수 호출 (to_tsvector, word_similarity, extract_chosung)
+ * - 인덱스 활용 최적화
+ *
+ * 검색 전략:
+ * 1. Full-Text Search: 띄어쓰기 무관 검색 (GIN 인덱스)
+ * 2. Trigram: 오타 교정 (GiST 인덱스)
+ * 3. Chosung: 초성 검색 (함수 기반 인덱스)
+ */
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class AuctionSearchRepositoryCustomImpl implements AuctionSearchRepositoryCustom {
+
+    private final EntityManager entityManager;
+
+    // ============================================
+    // SQL 쿼리 템플릿 상수
+    // ============================================
+
+    /**
+     * 기본 SELECT 절 (모든 검색 쿼리 공통)
+     */
+    private static final String BASE_SELECT = """
+        SELECT
+            a.auction_id,
+            ai.auction_item_id,
+            a.title,
+            img.image_url,
+            up.nickname,
+            a.current_price,
+            a.bid_count,
+            a.view_count,
+            a.favorite_count,
+            a.end_at,
+            a.status
+        FROM auctions a
+        INNER JOIN auction_items ai ON a.auction_item_id = ai.auction_item_id
+        INNER JOIN auction_images img ON img.auction_item_id = ai.auction_item_id AND img.display_order = 0
+        INNER JOIN users u ON a.seller_id = u.user_id
+        INNER JOIN user_profile up ON up.user_id = u.user_id
+        """;
+
+    /**
+     * 기본 ORDER BY 절 (생성일 기준 내림차순)
+     */
+    private static final String ORDER_BY_CREATED = "ORDER BY a.created_at DESC ";
+
+    /**
+     * 페이징 절
+     */
+    private static final String PAGINATION = "LIMIT :limit OFFSET :offset";
+
+    /**
+     * 기본 COUNT 절
+     */
+    private static final String BASE_COUNT = "SELECT COUNT(*) FROM auctions a ";
+
+    // ============================================
+    // 검색 메서드 구현
+    // ============================================
+
+    @Override
+    public Page<AuctionListDto> searchByFullText(String processedKeyword, AuctionStatus status, Pageable pageable) {
+        log.debug("Full-Text Search 실행: processedKeyword={}, status={}", processedKeyword, status);
+
+        // WHERE 조건
+        String whereClause = " WHERE to_tsvector('simple', a.title || ' ' || COALESCE(a.description, '')) @@ to_tsquery('simple', :processedKeyword) ";
+        String statusCondition = status != null ? "AND a.status = :status " : "";
+
+        // 메인 쿼리 조립
+        String sql = BASE_SELECT + whereClause + statusCondition + ORDER_BY_CREATED + PAGINATION;
+
+        Query query = createQueryWithParams(sql, processedKeyword, null, 0.0, status, pageable);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> results = query.getResultList();
+        List<AuctionListDto> content = convertToDto(results);
+
+        // Count 쿼리
+        String countSql = BASE_COUNT + whereClause + statusCondition;
+        long total = executeCountQuery(countSql, processedKeyword, null, 0.0, status);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<AuctionListDto> searchByTrigram(String keyword, double threshold, AuctionStatus status, Pageable pageable) {
+        log.debug("Trigram Similarity 검색 실행: keyword={}, threshold={}, status={}", keyword, threshold, status);
+
+        // WHERE 조건
+        String whereClause = "WHERE word_similarity(:keyword, a.title) > :threshold ";
+        String statusCondition = status != null ? "AND a.status = :status " : "";
+        String orderBy = "ORDER BY word_similarity(:keyword, a.title) DESC ";
+
+        // 메인 쿼리 조립
+        String sql = BASE_SELECT + whereClause + statusCondition + orderBy + PAGINATION;
+
+        Query query = createQueryWithParams(sql, keyword, keyword, threshold, status, pageable);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> results = query.getResultList();
+        List<AuctionListDto> content = convertToDto(results);
+
+        // Count 쿼리
+        String countSql = BASE_COUNT + whereClause + statusCondition;
+        long total = executeCountQuery(countSql, keyword, keyword, threshold, status);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<AuctionListDto> searchByChosung(String chosungKeyword, AuctionStatus status, Pageable pageable) {
+        log.debug("초성 검색 실행: chosungKeyword={}, status={}", chosungKeyword, status);
+
+        // WHERE 조건
+        String whereClause = "WHERE extract_chosung(a.title) LIKE :chosungPattern ";
+        String statusCondition = status != null ? "AND a.status = :status " : "";
+
+        // 메인 쿼리 조립
+        String sql = BASE_SELECT + whereClause + statusCondition + ORDER_BY_CREATED + PAGINATION;
+
+        Query query = createQueryWithParams(sql, chosungKeyword, null, 0.0, status, pageable);
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> results = query.getResultList();
+        List<AuctionListDto> content = convertToDto(results);
+
+        // Count 쿼리
+        String countSql = BASE_COUNT + whereClause + statusCondition;
+        long total = executeCountQuery(countSql, chosungKeyword, null, 0.0, status);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public List<String> getSuggestedKeywords() {
+        log.debug("추천 키워드 조회 실행");
+
+        String sql = """
+        WITH split_words AS (
+            SELECT DISTINCT 
+                regexp_split_to_table(a.title, E'\\\\s+') as word
+            FROM auctions a
+            WHERE a.status = 'LIVE'
+        )
+        SELECT word
+        FROM split_words
+        WHERE LENGTH(word) >= 2
+            AND word !~ '^[0-9]+$'
+        ORDER BY RANDOM()
+        LIMIT 5
+        """;
+
+        Query query = entityManager.createNativeQuery(sql);
+
+        @SuppressWarnings("unchecked")
+        List<String> results = query.getResultList();
+
+        return results != null ? results : new ArrayList<>();
+    }
+
+    // ============================================
+    // 헬퍼 메서드
+    // ============================================
+
+    /**
+     * 쿼리 생성 및 파라미터 바인딩
+     *
+     * @param sql SQL 쿼리
+     * @param processedKeywordOrPattern 키워드 또는 패턴 (Full-Text, Chosung용)
+     * @param keyword 키워드 (Trigram용)
+     * @param threshold 유사도 임계값 (Trigram용)
+     * @param status 경매 상태
+     * @param pageable 페이징 정보
+     * @return 파라미터가 바인딩된 Query 객체
+     */
+    private Query createQueryWithParams(
+            String sql,
+            String processedKeywordOrPattern,
+            String keyword,
+            double threshold,
+            AuctionStatus status,
+            Pageable pageable
+    ) {
+        Query query = entityManager.createNativeQuery(sql);
+
+        // Full-Text 또는 Chosung 검색
+        if (processedKeywordOrPattern != null) {
+            if (sql.contains(":processedKeyword")) {
+                query.setParameter("processedKeyword", processedKeywordOrPattern);
+            } else if (sql.contains(":chosungPattern")) {
+                query.setParameter("chosungPattern", processedKeywordOrPattern + "%");
+            }
+        }
+
+        // Trigram 검색
+        if (keyword != null && sql.contains(":keyword")) {
+            query.setParameter("keyword", keyword);
+        }
+
+        if (threshold > 0 && sql.contains(":threshold")) {
+            query.setParameter("threshold", threshold);
+        }
+
+        // 상태 필터
+        if (status != null) {
+            query.setParameter("status", status.name());
+        }
+
+        // 페이징
+        query.setParameter("limit", pageable.getPageSize());
+        query.setParameter("offset", pageable.getOffset());
+
+        return query;
+    }
+
+    /**
+     * Count 쿼리 실행
+     *
+     * @param countSql Count SQL
+     * @param processedKeywordOrPattern 키워드 또는 패턴 (Full-Text, Chosung용)
+     * @param keyword 키워드 (Trigram용)
+     * @param threshold 유사도 임계값 (Trigram용)
+     * @param status 경매 상태
+     * @return 전체 건수
+     */
+    private long executeCountQuery(
+            String countSql,
+            String processedKeywordOrPattern,
+            String keyword,
+            double threshold,
+            AuctionStatus status
+    ) {
+        Query countQuery = entityManager.createNativeQuery(countSql);
+
+        // Full-Text 또는 Chosung 검색
+        if (processedKeywordOrPattern != null) {
+            if (countSql.contains(":processedKeyword")) {
+                countQuery.setParameter("processedKeyword", processedKeywordOrPattern);
+            } else if (countSql.contains(":chosungPattern")) {
+                countQuery.setParameter("chosungPattern", processedKeywordOrPattern + "%");
+            }
+        }
+
+        // Trigram 검색
+        if (keyword != null && countSql.contains(":keyword")) {
+            countQuery.setParameter("keyword", keyword);
+        }
+
+        if (threshold > 0 && countSql.contains(":threshold")) {
+            countQuery.setParameter("threshold", threshold);
+        }
+
+        // 상태 필터
+        if (status != null) {
+            countQuery.setParameter("status", status.name());
+        }
+
+        return ((Number) countQuery.getSingleResult()).longValue();
+    }
+
+    /**
+     * Object[] → AuctionListDto 변환
+     */
+    private List<AuctionListDto> convertToDto(List<Object[]> results) {
+        List<AuctionListDto> dtos = new ArrayList<>();
+
+        for (Object[] row : results) {
+            AuctionListDto dto = new AuctionListDto(
+                    (UUID) row[0],                              // auction_id
+                    (Long) row[1],                              // auction_item_id
+                    (String) row[2],                            // title
+                    (String) row[3],                            // image_url
+                    (String) row[4],                            // nickname
+                    (Integer) row[5],                           // current_price
+                    (Integer) row[6],                           // bid_count
+                    (Integer) row[7],                           // view_count
+                    (Integer) row[8],                           // favorite_count
+                    convertToOffsetDateTime(row[9]),            // end_at
+                    AuctionStatus.valueOf((String) row[10])     // status
+            );
+            dtos.add(dto);
+        }
+
+        return dtos;
+    }
+
+    /**
+     * Object → OffsetDateTime 변환 (Timestamp 또는 Instant 처리)
+     */
+    private OffsetDateTime convertToOffsetDateTime(Object obj) {
+        if (obj == null) {
+            return null;
+        }
+
+        if (obj instanceof Timestamp) {
+            return ((Timestamp) obj).toInstant()
+                    .atZone(ZoneId.systemDefault())
+                    .toOffsetDateTime();
+        } else if (obj instanceof java.time.Instant) {
+            return ((java.time.Instant) obj)
+                    .atZone(ZoneId.systemDefault())
+                    .toOffsetDateTime();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/kr/eolmago/repository/search/SearchKeywordRepositoryCustom.java
+++ b/src/main/java/kr/eolmago/repository/search/SearchKeywordRepositoryCustom.java
@@ -53,6 +53,18 @@ public interface SearchKeywordRepositoryCustom {
     List<SearchKeyword> findTopBySearchCount(int limit);
 
     /**
+     * 초성 prefix 검색 (자동완성 - 초성)
+     *
+     * 예시:
+     * - "ㅇㅍ" 검색 → keyword_chosung LIKE 'ㅇㅍ%'
+     *
+     * @param chosungPrefix 초성 prefix
+     * @param limit 최대 개수
+     * @return 검색 결과 목록
+     */
+    List<SearchKeyword> findByChosungPrefix(String chosungPrefix, int limit);
+
+    /**
      * 오래된 키워드 정리 (배치 작업용)
      *
      * 동작:

--- a/src/main/java/kr/eolmago/repository/search/impl/SearchKeywordRepositoryImpl.java
+++ b/src/main/java/kr/eolmago/repository/search/impl/SearchKeywordRepositoryImpl.java
@@ -68,6 +68,16 @@ public class SearchKeywordRepositoryImpl implements SearchKeywordRepositoryCusto
                 .fetch();
     }
 
+    @Override
+    public List<SearchKeyword> findByChosungPrefix(String chosungPrefix, int limit) {
+        return queryFactory
+                .selectFrom(searchKeyword)
+                .where(searchKeyword.keywordChosung.startsWith(chosungPrefix))
+                .orderBy(searchKeyword.searchCount.desc())
+                .limit(limit)
+                .fetch();
+    }
+
     /**
      * 오래된 키워드 정리
      *

--- a/src/main/java/kr/eolmago/service/auction/AuctionSearchService.java
+++ b/src/main/java/kr/eolmago/service/auction/AuctionSearchService.java
@@ -1,0 +1,301 @@
+package kr.eolmago.service.auction;
+
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.dto.api.auction.response.AuctionListDto;
+import kr.eolmago.dto.api.auction.response.AuctionListResponse;
+import kr.eolmago.dto.api.common.PageResponse;
+import kr.eolmago.global.util.ChosungUtils;
+import kr.eolmago.repository.auction.AuctionSearchRepository;
+import kr.eolmago.service.search.SearchKeywordService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 경매 검색 Service
+ *
+ * 역할:
+ * - 통합 검색 로직 (초성 → Full-Text → Trigram)
+ * - 검색 타입 자동 판단
+ * - 검색어 통계 기록 연동
+ * - 추천 키워드 제공 (결과 없을 때)
+ *
+ * 검색 전략 (폴백 체인):
+ * 1. 키워드 타입 판단 (ChosungUtils)
+ * 2. 초성: searchByChosung()
+ * 3. 일반: searchByFullText()
+ * 4. 결과 없으면: searchByTrigram() (오타 교정)
+ * 5. 여전히 없으면: 빈 결과 (Controller에서 추천 키워드)
+ *
+ * 데이터 흐름:
+ * Repository → Page<AuctionListDto> (DTO 프로젝션)
+ * Service → Page<AuctionListDto> → PageResponse<AuctionListResponse>
+ * Controller → JSON 응답
+ *
+ * 책임 분리:
+ * - Repository: DTO 프로젝션, 데이터 조립
+ * - Service: 비즈니스 로직, DTO → Response 변환
+ * - DTO/Response: 계산 로직 없음 (순수 데이터)
+ */
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuctionSearchService {
+
+    private final AuctionSearchRepository auctionSearchRepository;
+    private final SearchKeywordService searchKeywordService;
+
+    /**
+     * 통합 검색
+     *
+     * 검색 흐름:
+     * 1. 키워드 검증 (빈 값 체크)
+     * 2. 키워드 타입 판단
+     *    - CHOSUNG: "ㅇㅍ" → 초성 검색
+     *    - HANGUL: "아이폰" → Full-Text 검색
+     *    - OTHER: "iPhone" → Full-Text 검색
+     *
+     * 3. 타입별 검색 실행
+     *    - 초성: searchByChosung()
+     *    - 일반: searchByFullTextWithFallback()
+     *
+     * 4. 결과 처리
+     *    - 있으면: 검색어 통계 기록
+     *    - 없으면: 빈 결과 (통계 기록 안 함)
+     *
+     * 데이터 변환:
+     * - Repository: Page<AuctionListDto>
+     * - Service: PageResponse<AuctionListResponse>
+     *
+     * @param keyword 검색 키워드
+     * @param status 경매 상태 (null이면 전체)
+     * @param pageable 페이지 정보
+     * @param userId 사용자 ID (통계 기록용, null 가능)
+     * @return 검색 결과 PageResponse<AuctionListResponse>
+     */
+    public PageResponse<AuctionListResponse> search(
+            String keyword,
+            AuctionStatus status,
+            Pageable pageable,
+            UUID userId
+    ) {
+        log.info("통합 검색 시작: keyword={}, status={}, page={}, userId={}", keyword, status, pageable.getPageNumber(), userId);
+
+        // 1. 키워드 검증
+        if (keyword == null || keyword.trim().isEmpty()) {
+            log.warn("빈 검색어로 검색 시도");
+            return PageResponse.of(Page.empty());
+        }
+
+        keyword = keyword.trim();
+
+        // 2. 키워드 타입 판단
+        String keywordType = ChosungUtils.getKeywordType(keyword);
+        log.info("키워드 타입: {}", keywordType);
+
+        // 3. 타입별 검색 실행
+        PageResponse<AuctionListResponse> result = switch (keywordType) {
+            case "CHOSUNG" -> {
+                log.debug("초성 검색 실행");
+                yield searchByChosung(keyword, status, pageable);
+            }
+            case "HANGUL", "MIXED", "OTHER" -> {
+                log.debug("Full-Text 검색 실행");
+                yield searchByFullTextWithFallback(keyword, status, pageable);
+            }
+            default -> {
+                log.warn("알 수 없는 키워드 타입: {}", keywordType);
+                yield PageResponse.of(Page.empty());
+            }
+        };
+
+        // 4. 검색 결과가 있으면 통계 기록
+        if (result.pageInfo().totalElements() > 0 /*&& userId != null*/) {
+            try {
+                searchKeywordService.recordSearch(keyword, userId);
+                log.debug("검색어 통계 기록 완료: keyword={}, userId={}", keyword, userId);
+            } catch (Exception e) {
+                // 통계 기록 실패해도 검색 결과는 반환
+                log.error("검색어 통계 기록 실패: keyword={}", keyword, e);
+            }
+        }
+
+        log.info("통합 검색 완료: keyword={}, results={}",
+                keyword, result.pageInfo().totalElements());
+
+        return result;
+    }
+
+    /**
+     * 추천 키워드 조회 (검색 결과 없을 때)
+     *
+     * 동작:
+     * - Repository에서 인기 검색어 기반 추천
+     * - 최대 5개 반환
+     *
+     * 사용 시나리오:
+     * - Controller에서 결과 없을 때 호출
+     * - "혹시 이런 키워드를 찾으셨나요?" 표시
+     *
+     * @return 추천 키워드 목록 (최대 5개)
+     */
+    public List<String> getSuggestedKeywords() {
+        log.debug("추천 키워드 조회");
+        return auctionSearchRepository.getSuggestedKeywords();
+    }
+
+    /**
+     * 초성 검색 실행
+     *
+     * 동작:
+     * 1. Repository에서 DTO 프로젝션 조회
+     * 2. 결과 있으면 Response 변환 후 반환
+     * 3. 결과 없으면 Full-Text로 폴백
+     *
+     * 데이터 흐름:
+     * - Repository: Page<AuctionListDto> (썸네일, 닉네임 조립됨)
+     * - Service: PageResponse<AuctionListResponse>
+     *
+     * 예시:
+     * - "ㅇㅇㅍ" 검색
+     *   → extract_chosung("아이폰 14") = "ㅇㅇㅍ 14"
+     *   → LIKE 'ㅇㅇㅍ%' 매칭 ✅
+     *
+     * - "ㅇㅍ" 검색
+     *   → 정확한 초성 순서 필요
+     *   → 매칭 실패 → Full-Text 폴백
+     *
+     * @param keyword 초성 키워드
+     * @param status 경매 상태
+     * @param pageable 페이지 정보
+     * @return 검색 결과
+     */
+    private PageResponse<AuctionListResponse> searchByChosung(
+            String keyword,
+            AuctionStatus status,
+            Pageable pageable
+    ) {
+        log.debug("초성 검색 실행: keyword={}", keyword);
+
+        // 1. 초성 패턴 (LIKE 'ㅇㅇㅍ%')
+        String chosungPattern = keyword + "%";
+
+        // 2. 초성 검색 (Native Query)
+        Page<AuctionListDto> dtoPage = auctionSearchRepository.searchByChosung(
+                chosungPattern,
+                status != null ? AuctionStatus.valueOf(status.name()) : null,
+                pageable
+        );
+
+        // 2. 결과가 있으면 Response 변환 후 반환
+        if (dtoPage.hasContent()) {
+            log.debug("초성 검색 성공: {} 건", dtoPage.getTotalElements());
+            return PageResponse.of(dtoPage, AuctionListResponse::from);
+        }
+
+        // 3. 결과 없으면 Full-Text로 폴백
+        log.debug("초성 검색 결과 없음, Full-Text로 폴백");
+        return searchByFullTextWithFallback(keyword, status, pageable);
+    }
+
+    /**
+     * Full-Text 검색 + Trigram 폴백
+     *
+     * 동작:
+     * 1. Full-Text Search 실행 (Repository DTO 프로젝션)
+     * 2. 결과 없으면 Trigram으로 폴백 (오타 교정)
+     * 3. 여전히 없으면 빈 결과 반환
+     *
+     * 데이터 흐름:
+     * - Repository: Page<AuctionListDto> (DTO 프로젝션)
+     * - Service: DTO → Response 변환
+     *
+     * 예시:
+     * - "아이폰" 검색
+     *   → Full-Text 매칭 ✅
+     *   → 결과 반환
+     *
+     * - "아이혼" 검색 (오타)
+     *   → Full-Text 매칭 실패
+     *   → Trigram 유사도 검색
+     *   → similarity("아이폰", "아이혼") = 0.6
+     *   → "아이폰" 결과 반환 ✅
+     *
+     * - "존재하지않는키워드" 검색
+     *   → Full-Text 실패
+     *   → Trigram 실패
+     *   → 빈 결과 (Controller에서 추천 키워드 제공)
+     *
+     * @param keyword 검색 키워드
+     * @param status 경매 상태
+     * @param pageable 페이지 정보
+     * @return 검색 결과
+     */
+    private PageResponse<AuctionListResponse> searchByFullTextWithFallback(
+            String keyword,
+            AuctionStatus status,
+            Pageable pageable
+    ) {
+        log.info("Full-Text 검색 실행: keyword={}, status={}, pageable={} ", keyword, status, pageable);
+
+        // 1. 키워드 전처리 (공백을 & 로 변환)
+        String processedKeyword = keyword.trim()
+                .replaceAll("[,.:;!?]", " ")
+                .replaceAll("\\s+", " & ");
+
+        // 2. Full-Text Search (Native Query)
+        Page<AuctionListDto> dtoPage = auctionSearchRepository.searchByFullText(
+                processedKeyword,
+                status,
+                pageable
+        );
+
+        // 2. 결과가 있으면 Response 변환 후 반환
+        if (dtoPage.hasContent()) {
+            log.debug("Full-Text 검색 성공: {} 건", dtoPage.getTotalElements());
+            return PageResponse.of(dtoPage, AuctionListResponse::from);
+        }
+
+        // 3. 결과 없으면 Trigram으로 폴백 (오타 교정)
+        log.debug("Full-Text 검색 결과 없음, Trigram으로 폴백");
+        dtoPage = auctionSearchRepository.searchByTrigram(
+                processedKeyword,
+                getDynamicThreshold(processedKeyword),
+                status,
+                pageable
+        );
+
+        // 4. Trigram 결과 반환 (없어도 빈 Page)
+        if (dtoPage.hasContent()) {
+            log.debug("Trigram 검색 성공: {} 건", dtoPage.getTotalElements());
+        } else {
+            log.debug("모든 검색 전략 실패");
+        }
+
+        return PageResponse.of(dtoPage, AuctionListResponse::from);
+    }
+
+    /**
+     * 키워드 길이에 따라 동적으로 threshold 조정
+     */
+    private double getDynamicThreshold(String keyword) {
+        int length = keyword.length();
+        System.out.println("length: " + length);
+
+        if (length <= 2) {
+            return 0.5;  // 짧은 키워드는 엄격하게
+        } else if (length <= 4) {
+            return 0.3;  // 중간 길이
+        } else {
+            return 0.25; // 긴 키워드는 관대하게
+        }
+    }
+}
+


### PR DESCRIPTION
## 이슈 번호
- Closes #23

## 작업 내용
- 전문 검색(Full Text Search) 기능 구현: 
PostgreSQL의 pg_trgm 확장 모듈과 to_tsvector를 활용하여 키워드 검색 성능을 최적화하고, 유사도 기반 검색을 지원하도록 구현.
- 초성 검색 지원: 
chosung_extract 함수를 DB에 등록하고, SearchKeyword 엔티티에 keyword_chosung 컬럼(Generated Column)을 추가하여 초성 자동완성 기능구현.
- API 엔드포인트만 구현 완료. 빠른 시일내에 view로 전환할 예정 
- 실제 개발/운영 DB 환경에 맞춰 설정을 정리완료.