### PR TITLE
[260109] feat: 필터링 & 정렬 api/view 기능 구현 #69

### DIFF
--- a/src/main/java/kr/eolmago/controller/api/auction/AuctionApiController.java
+++ b/src/main/java/kr/eolmago/controller/api/auction/AuctionApiController.java
@@ -4,28 +4,36 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.domain.entity.auction.enums.ItemCategory;
 import kr.eolmago.dto.api.auction.request.AuctionDraftRequest;
 import kr.eolmago.dto.api.auction.response.AuctionDraftDetailResponse;
 import kr.eolmago.dto.api.auction.response.AuctionDraftResponse;
 import kr.eolmago.dto.api.auction.response.AuctionListResponse;
 import kr.eolmago.dto.api.common.PageResponse;
 import kr.eolmago.global.security.CustomUserDetails;
+import kr.eolmago.service.auction.AuctionSearchService;
 import kr.eolmago.service.auction.AuctionService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/auctions")
 @Tag(name = "Auction")
 @RequiredArgsConstructor
+@Slf4j
 public class AuctionApiController {
 
     private final AuctionService auctionService;
+    private final AuctionSearchService auctionSearchService;
 
     @Operation(summary = "경매 임시저장 생성")
     @PostMapping("/drafts")
@@ -82,16 +90,46 @@ public class AuctionApiController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(summary = "경매 목록 조회")
+    @Operation(summary = "경매 목록 조회",
+            description = "검색어, 필터, 정렬 조건으로 경매 목록을 조회합니다. " +
+                    "키워드가 없으면 전체 목록을 반환하고, 키워드가 있으면 검색 결과를 반환합니다."
+    )
     @GetMapping
     public ResponseEntity<PageResponse<AuctionListResponse>> getAuctions (
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "12") int size,
             @RequestParam(defaultValue = "latest") String sort,
             @RequestParam(required = false) AuctionStatus status,
-            @RequestParam(required = false) UUID sellerId
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) ItemCategory category,
+            @RequestParam(required = false) List<String> brands,
+            @RequestParam(required = false) Integer minPrice,
+            @RequestParam(required = false) Integer maxPrice,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        PageResponse<AuctionListResponse> response = auctionService.getAuctions(page, size, sort, status, sellerId);
+        log.info("경매 목록 조회 API: keyword={}, category={}, brands={}, minPrice={}, maxPrice={}, sort={}, page={}", keyword, category, brands, minPrice, maxPrice, sort, page);
+
+        // 사용자ID 추출(비로그인시 null, 검색 통계용)
+        UUID userId = userDetails != null ? UUID.fromString(userDetails.getId()) : null;
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        // 키워드 있으면 검색, 없으면 전체조회 (서비스단에서)
+        PageResponse<AuctionListResponse> response = auctionSearchService.search(
+                keyword,
+                category,
+                brands,
+                minPrice,
+                maxPrice,
+                sort,
+                status,
+                pageable,
+                userId
+        );
+
+        log.info("경매 목록 조회 완료: totalElements={}", response.pageInfo().totalElements());
+
+        /* PageResponse<AuctionListResponse> response = auctionService.getAuctions(page, size, sort, status, sellerId, category, brands, minPrice, maxPrice);*/
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/kr/eolmago/controller/api/search/SearchApiController.java
+++ b/src/main/java/kr/eolmago/controller/api/search/SearchApiController.java
@@ -1,16 +1,11 @@
 package kr.eolmago.controller.api.search;
 
-import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
-import kr.eolmago.dto.api.auction.response.AuctionListResponse;
-import kr.eolmago.dto.api.common.PageResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.eolmago.dto.api.search.response.AutocompleteResponse;
 import kr.eolmago.dto.api.search.response.PopularKeywordResponse;
-import kr.eolmago.service.auction.AuctionSearchService;
 import kr.eolmago.service.search.SearchKeywordService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,70 +26,12 @@ import java.util.UUID;
  */
 @RestController
 @RequestMapping("/api/search")
+@Tag(name = "Search", description = "검색 부가 기능API")
 @Slf4j
 @RequiredArgsConstructor
 public class SearchApiController {
 
     private final SearchKeywordService searchKeywordService;
-    private final AuctionSearchService auctionSearchService;
-
-    /**
-     * 경매 검색 API
-     *
-     * 사용 예시:
-     * ```
-     * GET /api/search?keyword=아이폰&status=LIVE&page=0&size=20
-     * GET /api/search?keyword=ㅇㅍ&page=0
-     * GET /api/search?keyword=아이혼&page=0  (오타 교정)
-     * ```
-     *
-     * 검색 전략:
-     * 1. 초성: "ㅇㅇㅍ" → 초성 검색
-     * 2. 일반: "아이폰" → Full-Text 검색
-     * 3. 오타: "아이혼" → Trigram 유사도 검색
-     * 4. 실패: 추천 키워드 제공
-     *
-     * @param keyword 검색 키워드 (필수)
-     * @param status 경매 상태 (선택, 기본: 전체)
-     * @param page 페이지 번호 (0-based, 기본: 0)
-     * @param size 페이지 크기 (기본: 20)
-     * @param userId 사용자 ID (선택, 통계 기록용)
-     * @return 검색 결과 + 추천 키워드 (결과 없을 때)
-     */
-    @GetMapping
-    public ResponseEntity<Map<String, Object>> search(
-            @RequestParam String keyword,
-            @RequestParam(required = false) AuctionStatus status,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size,
-            @RequestParam(required = false) UUID userId
-    ) {
-        log.info("검색 API 호출: keyword={}, status={}, page={}", keyword, status, page);
-
-        // 1. 페이지 정보 생성
-        Pageable pageable = PageRequest.of(page, size);
-
-        // 2. 검색 실행 (Service에서 통합 검색)
-        PageResponse<AuctionListResponse> results = auctionSearchService.search(
-                keyword,
-                status,
-                pageable,
-                userId
-        );
-
-        // 3. 응답 구성
-        Map<String, Object> response = new HashMap<>();
-        response.put("results", results);
-
-        // 4. 검색 결과 없으면 추천 키워드 제공
-        if (results.pageInfo().totalElements() == 0) {
-            List<String> suggestions = auctionSearchService.getSuggestedKeywords();
-            response.put("suggestions", suggestions);
-            log.debug("검색 결과 없음, 추천 키워드 제공: {}", suggestions);
-        }
-
-        return ResponseEntity.ok(response);
-    }
 
     /**
      * 자동완성 API

--- a/src/main/java/kr/eolmago/controller/view/auction/AuctionViewController.java
+++ b/src/main/java/kr/eolmago/controller/view/auction/AuctionViewController.java
@@ -1,6 +1,7 @@
 package kr.eolmago.controller.view.auction;
 
 import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.domain.entity.auction.enums.ItemCategory;
 import kr.eolmago.dto.api.auction.response.AuctionListResponse;
 import kr.eolmago.dto.api.common.PageResponse;
 import kr.eolmago.global.security.CustomUserDetails;
@@ -36,41 +37,47 @@ public class AuctionViewController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "8") int size,
             @RequestParam(defaultValue = "latest") String sort,
-            @RequestParam(required = false) UUID sellerId,
+//            @RequestParam(required = false) UUID sellerId,
             @RequestParam(required = false) String keyword,  // 검색어
+            @RequestParam(required = false) ItemCategory category,
+            @RequestParam(required = false) List<String> brands,
+            @RequestParam(required = false) Integer minPrice,
+            @RequestParam(required = false) Integer maxPrice,
             @AuthenticationPrincipal CustomUserDetails userDetails,  // (검색통계용) 사용자 정보
             Model model) {
+
+        log.info("경매 목록 조회 API: keyword={}, category={}, brands={}, minPrice={}, maxPrice={}, sort={}, page={}", keyword, category, brands, minPrice, maxPrice, sort, page);
 
         // 경매 검색 및 목록은 LIVE 상태만 조회
         AuctionStatus searchStatus = AuctionStatus.LIVE;
 
-        // 경매 목록 조회
-        PageResponse<AuctionListResponse> auctions;
+        // 사용자ID 추출(비로그인시 null, 검색 통계용)
+        UUID userId = userDetails != null ? UUID.fromString(userDetails.getId()) : null;
+
+        // Pageable 생성
+        Pageable pageable = PageRequest.of(page, size);
+
+        // 키워드 있으면 검색, 없으면 전체조회 (서비스단에서)
+        PageResponse<AuctionListResponse> auctions = auctionSearchService.search(
+                keyword,
+                category,
+                brands,
+                minPrice,
+                maxPrice,
+                sort,
+                searchStatus,
+                pageable,
+                userId
+        );
 
         // 검색 모드 분기 처리
         boolean isSearchMode = keyword != null && !keyword.trim().isEmpty();
 
-        if (isSearchMode) {
-            log.info("검색 모드: keyword={}, page={}", keyword, page);
-            // userDetails가 null이면 비로그인 사용자
-            UUID userId = userDetails != null ? userDetails.getUserId() : null;
-
-            Pageable pageable = PageRequest.of(page, size);
-            auctions = auctionSearchService.search(keyword.trim(), searchStatus, pageable, userId);
-
-            // 검색 결과 없을 때 추천 키워드 조회
-            if (auctions.pageInfo().totalElements() == 0) {
-                List<String> suggestedKeywords = auctionSearchService.getSuggestedKeywords();
-                model.addAttribute("suggestedKeywords", suggestedKeywords);
-                log.info("검색 결과 없음, 추천 키워드: {}", suggestedKeywords);
-            }
-
-            model.addAttribute("keyword", keyword.trim());
-            model.addAttribute("isSearchMode", true);
-        } else {
-            log.info("일반 목록 모드: page={}, sort={}", page, sort);
-            auctions = auctionService.getAuctions(page, size, sort, searchStatus, sellerId);
-            model.addAttribute("isSearchMode", false);
+        // 검색 결과 없을 때 추천 키워드 조회
+        if (isSearchMode && auctions.pageInfo().totalElements() == 0) {
+            List<String> suggestedKeywords = auctionSearchService.getSuggestedKeywords();
+            model.addAttribute("suggestedKeywords", suggestedKeywords);
+            log.info("검색 결과 없음, 추천 키워드: {}", suggestedKeywords);
         }
 
         log.info("경매 목록 조회 - 총 {}개, 현재 페이지: {}",
@@ -82,13 +89,19 @@ public class AuctionViewController {
                 Map.of("value", "latest", "label", "최신순"),
                 Map.of("value", "popular", "label", "인기순"),
                 Map.of("value", "deadline", "label", "마감임박순"),
-                Map.of("value", "highPrice", "label", "높은가격순"),
-                Map.of("value", "lowPrice", "label", "낮은가격순")
+                Map.of("value", "price_low", "label", "낮은가격순"),
+                Map.of("value", "price_high", "label", "높은가격순")
         );
 
         model.addAttribute("auctions", auctions);
         model.addAttribute("sortOptions", sortOptions);
         model.addAttribute("sort", sort);
+        model.addAttribute("keyword", keyword);
+        model.addAttribute("category", category);
+        model.addAttribute("brands", brands);
+        model.addAttribute("minPrice", minPrice);
+        model.addAttribute("maxPrice", maxPrice);
+        model.addAttribute("isSearchMode", isSearchMode);
 
         return "pages/auction/auction-list";
     }

--- a/src/main/java/kr/eolmago/global/util/ItemCategoryUtils.java
+++ b/src/main/java/kr/eolmago/global/util/ItemCategoryUtils.java
@@ -1,0 +1,39 @@
+package kr.eolmago.global.util;
+
+import kr.eolmago.domain.entity.auction.enums.ItemCategory;
+
+/**
+ * ItemCategory Enum 유틸리티
+ * - Enum ↔ 한글 표시명 변환
+ */
+public class ItemCategoryUtils {
+
+    /**
+     * Enum → 한글 표시명
+     */
+    public static String getDisplayName(ItemCategory category) {
+        if (category == null) {
+            return "전체";
+        }
+
+        return switch (category) {
+            case PHONE -> "핸드폰";
+            case TABLET -> "태블릿";
+        };
+    }
+
+    /**
+     * 한글 표시명 → Enum (필요시 사용)
+     */
+    public static ItemCategory fromDisplayName(String displayName) {
+        if (displayName == null || displayName.isEmpty()) {
+            return null;
+        }
+
+        return switch (displayName) {
+            case "핸드폰" -> ItemCategory.PHONE;
+            case "태블릿" -> ItemCategory.TABLET;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/kr/eolmago/repository/auction/AuctionRepositoryCustom.java
+++ b/src/main/java/kr/eolmago/repository/auction/AuctionRepositoryCustom.java
@@ -1,14 +1,25 @@
 package kr.eolmago.repository.auction;
 
 import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.domain.entity.auction.enums.ItemCategory;
 import kr.eolmago.dto.api.auction.response.AuctionListDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface AuctionRepositoryCustom {
 
     // 경매 목록 조회
-    Page<AuctionListDto> searchList(Pageable pageable, String sortKey, AuctionStatus status, UUID sellerId);
+    Page<AuctionListDto> searchList(
+            Pageable pageable,
+            String sortKey,
+            AuctionStatus status,
+            UUID userId,
+            ItemCategory category,
+            List<String> brands,
+            Integer minPrice,
+            Integer maxPrice
+    );
 }

--- a/src/main/java/kr/eolmago/repository/auction/AuctionSearchRepositoryCustom.java
+++ b/src/main/java/kr/eolmago/repository/auction/AuctionSearchRepositoryCustom.java
@@ -1,6 +1,7 @@
 package kr.eolmago.repository.auction;
 
 import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.domain.entity.auction.enums.ItemCategory;
 import kr.eolmago.dto.api.auction.response.AuctionListDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,24 +16,52 @@ import java.util.List;
  * - QueryDSL 대신 @Query 사용
  *
  * 구현체:
- * - AuctionSearchRepositoryImpl
+ * - AuctionSearchRepositoryCustomImpl
  */
 public interface AuctionSearchRepositoryCustom {
 
     /**
-     * Full-Text Search (PostgreSQL to_tsvector)
+     * Full-Text Search (PostgreSQL to_tsvector, 필터링 포함)
      */
-    Page<AuctionListDto> searchByFullText(String keyword, AuctionStatus status, Pageable pageable);
+    Page<AuctionListDto> searchByFullText(
+            String keyword,
+            ItemCategory category,
+            List<String> brands,
+            Integer minPrice,
+            Integer maxPrice,
+            String sort,
+            AuctionStatus status,
+            Pageable pageable
+    );
 
     /**
-     * Trigram Similarity (PostgreSQL pg_trgm)
+     * 오타 교정 : Trigram Similarity (PostgreSQL pg_trgm, 필터링 포함)
      */
-    Page<AuctionListDto> searchByTrigram(String keyword, double threshold, AuctionStatus status, Pageable pageable);
+    Page<AuctionListDto> searchByTrigram(
+            String keyword,
+            double threshold,
+            ItemCategory category,
+            List<String> brands,
+            Integer minPrice,
+            Integer maxPrice,
+            String sort,
+            AuctionStatus status,
+            Pageable pageable
+    );
 
     /**
-     * 초성 검색 (extract_chosung 함수)
+     * 초성 검색 (extract_chosung 함수, 필터링 포함)
      */
-    Page<AuctionListDto> searchByChosung(String chosungKeyword, AuctionStatus status, Pageable pageable);
+    Page<AuctionListDto> searchByChosung(
+            String chosungKeyword,
+            ItemCategory category,
+            List<String> brands,
+            Integer minPrice,
+            Integer maxPrice,
+            String sort,
+            AuctionStatus status,
+            Pageable pageable
+    );
 
     /**
      * 추천 키워드 조회

--- a/src/main/java/kr/eolmago/service/auction/AuctionService.java
+++ b/src/main/java/kr/eolmago/service/auction/AuctionService.java
@@ -10,9 +10,9 @@ import kr.eolmago.domain.entity.user.User;
 import kr.eolmago.dto.api.auction.request.AuctionDraftRequest;
 import kr.eolmago.dto.api.auction.response.AuctionDraftDetailResponse;
 import kr.eolmago.dto.api.auction.response.AuctionDraftResponse;
+import kr.eolmago.dto.api.auction.response.AuctionListDto;
 import kr.eolmago.dto.api.auction.response.AuctionListResponse;
 import kr.eolmago.dto.api.common.PageResponse;
-import kr.eolmago.dto.api.auction.response.AuctionListDto;
 import kr.eolmago.global.exception.BusinessException;
 import kr.eolmago.global.exception.ErrorCode;
 import kr.eolmago.global.util.BidIncrementCalculator;
@@ -204,10 +204,20 @@ public class AuctionService {
     }
 
     // 경매 목록 조회
-    public PageResponse<AuctionListResponse> getAuctions(int page, int size, String sortKey, AuctionStatus status, UUID sellerId) {
+    public PageResponse<AuctionListResponse> getAuction(
+        int page,
+        int size,
+        String sortKey,
+        AuctionStatus status,
+        UUID sellerId,
+        ItemCategory category,
+        List<String> brands,
+        Integer minPrice,
+        Integer maxPrice
+    ) {
         Pageable pageable = PageRequest.of(page, size);
 
-        Page<AuctionListDto> dtoPage = auctionRepository.searchList(pageable, sortKey, status, sellerId);
+        Page<AuctionListDto> dtoPage = auctionRepository.searchList(pageable, sortKey, status, sellerId, category, brands, minPrice, maxPrice);
         Page<AuctionListResponse> responsePage = dtoPage.map(AuctionListResponse::from);
 
         return PageResponse.of(responsePage);

--- a/src/main/java/kr/eolmago/service/search/SearchKeywordService.java
+++ b/src/main/java/kr/eolmago/service/search/SearchKeywordService.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 /**
- * 검색 키워드 서비스
+ * 검색 부가 서비스
  *
  * 핵심 역할:
  * 1. Redis 기반 실시간 자동완성 제공

--- a/src/main/resources/static/js/auction/auction-list.js
+++ b/src/main/resources/static/js/auction/auction-list.js
@@ -1,0 +1,38 @@
+// /static/js/auction-list.js
+document.addEventListener("DOMContentLoaded", () => {
+    const minInput = document.getElementById("minPriceInput");
+    const maxInput = document.getElementById("maxPriceInput");
+    const form = document.querySelector('form[method="get"]');
+
+    if (!minInput || !maxInput || !form) return;
+
+    const numberFormatter = new Intl.NumberFormat("ko-KR");
+
+    // 숫자만 남기고 콤마 붙이기
+    function formatWithComma(el) {
+        const raw = el.value.replace(/[^\d]/g, ""); // 숫자만
+        if (raw.length === 0) {
+            el.value = "";
+            return;
+        }
+        // 너무 큰 값 방지(선택): 필요 없으면 제거
+        // const safe = raw.slice(0, 12);
+
+        el.value = numberFormatter.format(Number(raw));
+    }
+
+    // submit 전에 콤마 제거해서 서버에는 숫자만 가게
+    function stripComma(el) {
+        el.value = el.value.replace(/[^\d]/g, "");
+    }
+
+    // 입력할 때마다 콤마 포맷
+    minInput.addEventListener("input", () => formatWithComma(minInput));
+    maxInput.addEventListener("input", () => formatWithComma(maxInput));
+
+    // 폼 전송 직전 콤마 제거
+    form.addEventListener("submit", () => {
+        stripComma(minInput);
+        stripComma(maxInput);
+    });
+});

--- a/src/main/resources/templates/pages/auction/auction-list.html
+++ b/src/main/resources/templates/pages/auction/auction-list.html
@@ -29,9 +29,130 @@
             </div>
         </div>
 
-        <!-- 카테고리 -->
+        <!-- 필터 폼 -->
+        <form method="get" th:action="@{/auctions}" class="mb-8 bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+            <!-- 2열 그리드 컨테이너 -->
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-6">
+                <!-- 왼쪽 열 -->
+                <div class="space-y-6">
+                    <!-- 카테고리 필터 -->
+                    <div>
+                        <label class="block text-sm font-semibold text-gray-900 mb-3">카테고리</label>
+                        <div class="flex flex-wrap gap-4">
+                            <label class="inline-flex items-center cursor-pointer">
+                                <input type="radio" name="category" value=""
+                                       th:checked="${category == null}"
+                                       class="rounded-full border-gray-300 text-gray-900 focus:ring-gray-900 cursor-pointer">
+                                <span class="ml-2 text-sm text-gray-700">전체</span>
+                            </label>
+                            <label class="inline-flex items-center cursor-pointer">
+                                <input type="radio" name="category" value="PHONE"
+                                       th:checked="${category != null and category.name() == 'PHONE'}"
+                                       class="rounded-full border-gray-300 text-gray-900 focus:ring-gray-900 cursor-pointer">
+                                <span class="ml-2 text-sm text-gray-700">핸드폰</span>
+                            </label>
+                            <label class="inline-flex items-center cursor-pointer">
+                                <input type="radio" name="category" value="TABLET"
+                                       th:checked="${category != null and category.name() == 'TABLET'}"
+                                       class="rounded-full border-gray-300 text-gray-900 focus:ring-gray-900 cursor-pointer">
+                                <span class="ml-2 text-sm text-gray-700">태블릿</span>
+                            </label>
+                        </div>
+                    </div>
 
-        <!-- 필터 -->
+                    <!-- 가격 범위 필터 -->
+                    <div>
+                        <label class="block text-sm font-semibold text-gray-900 mb-3">가격 범위</label>
+                        <div class="flex items-center gap-3">
+                            <!-- minPrice -->
+                            <input id="minPriceInput"
+                                   type="text"
+                                   name="minPrice"
+                                   inputmode="numeric"
+                                   autocomplete="off"
+                                   th:value="${minPrice != null ? #numbers.formatInteger(minPrice, 0, 'COMMA') : ''}"
+                                   placeholder="최소 가격"
+                                   class="w-full rounded-xl border border-gray-300 bg-white py-3 pl-10 pr-4 text-sm outline-none transition
+                                          focus:border-gray-900 focus:ring-4 focus:ring-gray-900/10">
+
+                            <span class="text-sm text-gray-500">~</span>
+
+                            <!-- maxPrice -->
+                            <input id="maxPriceInput"
+                                   type="text"
+                                   name="maxPrice"
+                                   inputmode="numeric"
+                                   autocomplete="off"
+                                   th:value="${maxPrice != null ? #numbers.formatInteger(maxPrice, 0, 'COMMA') : ''}"
+                                   placeholder="최대 가격"
+                                   class="w-full rounded-xl border border-gray-300 bg-white py-3 pl-10 pr-4 text-sm outline-none transition
+                                          focus:border-gray-900 focus:ring-4 focus:ring-gray-900/10">
+
+                            <span class="text-sm text-gray-500">원</span>
+                        </div>
+                    </div>
+
+                </div>
+
+                <!-- 오른쪽 열 -->
+                <div class="space-y-6">
+                    <!-- 브랜드 필터 -->
+                    <div>
+                        <label class="block text-sm font-semibold text-gray-900 mb-3">브랜드</label>
+                        <div class="flex flex-wrap gap-4">
+                            <label class="inline-flex items-center cursor-pointer">
+                                <input type="checkbox" name="brands" value="Apple"
+                                       th:checked="${brands != null and brands.contains('Apple')}"
+                                       class="rounded border-gray-300 text-gray-900 focus:ring-gray-900 cursor-pointer">
+                                <span class="ml-2 text-sm text-gray-700">Apple</span>
+                            </label>
+                            <label class="inline-flex items-center cursor-pointer">
+                                <input type="checkbox" name="brands" value="Samsung"
+                                       th:checked="${brands != null and brands.contains('Samsung')}"
+                                       class="rounded border-gray-300 text-gray-900 focus:ring-gray-900 cursor-pointer">
+                                <span class="ml-2 text-sm text-gray-700">Samsung</span>
+                            </label>
+                            <label class="inline-flex items-center cursor-pointer">
+                                <input type="checkbox" name="brands" value="기타"
+                                       th:checked="${brands != null and brands.contains('기타')}"
+                                       class="rounded border-gray-300 text-gray-900 focus:ring-gray-900 cursor-pointer">
+                                <span class="ml-2 text-sm text-gray-700">기타</span>
+                            </label>
+                        </div>
+                    </div>
+
+                    <!-- 정렬 옵션 -->
+                    <div>
+                        <label class="block text-sm font-semibold text-gray-900 mb-3">정렬</label>
+                        <select name="sort"
+                                class="w-full rounded-md border-gray-300 text-sm focus:border-gray-900 focus:ring-gray-900">
+                            <option th:each="option : ${sortOptions}"
+                                    th:value="${option.value}"
+                                    th:text="${option.label}"
+                                    th:selected="${sort == option.value}">
+                            </option>
+                        </select>
+                    </div>
+
+                </div>
+
+            </div>
+
+            <!-- 키워드 유지 (hidden) -->
+            <input type="hidden" name="keyword" th:value="${keyword}">
+
+            <!-- 버튼 (전체 너비, 하단) -->
+            <div class="mt-6 flex gap-3 justify-center">
+                <button type="submit"
+                        class="px-8 py-2.5 bg-gray-900 text-white text-sm font-semibold rounded-md hover:bg-gray-800 transition-colors">
+                    필터 적용
+                </button>
+                <a th:href="@{/auctions}"
+                   class="inline-flex items-center px-8 py-2.5 border border-gray-300 text-gray-700 text-sm font-semibold rounded-md hover:bg-gray-50 transition-colors">
+                    초기화
+                </a>
+            </div>
+        </form>
 
         <!-- 검색 결과 없음 (추천 키워드 포함) -->
         <div th:if="${auctions.content.isEmpty() and isSearchMode}"
@@ -80,12 +201,12 @@
             <p class="mt-2 text-sm text-gray-600">나중에 다시 확인해주세요.</p>
         </div>
 
-        <!-- 페이지네이션 (검색 keyword 파라미터 유지) -->
-        <div th:if="${!auctions.content.isEmpty() and auctions.pageInfo.totalPages > 0}" class="mt-10">
+        <!-- 페이지네이션 (검색 keyword + 필터 파라미터 유지) -->
+        <div th:if="${!auctions.content.isEmpty() and auctions.pageInfo.totalPages > 1}" class="mt-10">
             <nav class="flex items-center justify-center gap-2" aria-label="Pagination">
                 <!-- 이전 페이지 -->
                 <a th:if="${auctions.pageInfo.hasPrevious}"
-                   th:href="@{/auctions(page=${auctions.pageInfo.currentPage - 1})}"
+                   th:href="@{/auctions(page=${auctions.pageInfo.currentPage - 1}, keyword=${keyword}, category=${category}, brands=${brands}, minPrice=${minPrice}, maxPrice=${maxPrice}, sort=${sort})}"
                    class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-300 bg-white text-sm font-semibold text-gray-700 hover:bg-gray-50">
                     <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
@@ -93,18 +214,31 @@
                 </a>
 
                 <!-- 페이지 번호 -->
-                <div class="flex gap-1" th:if="${auctions.pageInfo.totalPages > 0}">
-                    <a th:each="i : ${#numbers.sequence(0, auctions.pageInfo.totalPages - 1)}"
-                       th:href="@{/auctions(page=${i}, keyword=${keyword})}"
-                       th:classappend="${i == auctions.pageInfo.currentPage} ? 'bg-slate-900 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'"
-                       class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-300 text-sm font-semibold">
-                        <span th:text="${i + 1}">1</span>
-                    </a>
+                <div class="flex gap-1">
+                    <th:block th:each="i : ${#numbers.sequence(0, auctions.pageInfo.totalPages - 1)}">
+                        <!-- 현재 페이지 근처만 표시 (최대 7개) -->
+                        <a th:if="${i == 0 || i == auctions.pageInfo.totalPages - 1 || (i >= auctions.pageInfo.currentPage - 2 && i <= auctions.pageInfo.currentPage + 2)}"
+                           th:href="@{/auctions(page=${i}, keyword=${keyword}, category=${category}, brands=${brands}, minPrice=${minPrice}, maxPrice=${maxPrice}, sort=${sort})}"
+                           th:classappend="${i == auctions.pageInfo.currentPage} ? 'bg-gray-900 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'"
+                           class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-300 text-sm font-semibold transition-colors">
+                            <span th:text="${i + 1}">1</span>
+                        </a>
+
+                        <!-- ... 표시 -->
+                        <span th:if="${i == 1 && auctions.pageInfo.currentPage > 3}"
+                              class="inline-flex h-10 w-10 items-center justify-center text-gray-500">
+                            ...
+                        </span>
+                        <span th:if="${i == auctions.pageInfo.totalPages - 2 && auctions.pageInfo.currentPage < auctions.pageInfo.totalPages - 4}"
+                              class="inline-flex h-10 w-10 items-center justify-center text-gray-500">
+                            ...
+                        </span>
+                    </th:block>
                 </div>
 
                 <!-- 다음 페이지 -->
                 <a th:if="${auctions.pageInfo.hasNext}"
-                   th:href="@{/auctions(page=${auctions.pageInfo.currentPage + 1}, keyword=${keyword})}"
+                   th:href="@{/auctions(page=${auctions.pageInfo.currentPage + 1}, keyword=${keyword}, category=${category}, brands=${brands}, minPrice=${minPrice}, maxPrice=${maxPrice}, sort=${sort})}"
                    class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-300 bg-white text-sm font-semibold text-gray-700 hover:bg-gray-50">
                     <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
@@ -115,5 +249,10 @@
 
     </div>
 </div>
+
+<th:block layout:fragment="scripts">
+    <script th:src="@{/js/auction/auction-list.js}" defer></script>
+</th:block>
+
 </body>
 </html>


### PR DESCRIPTION
## 이슈 번호
- Closes #69 

## 작업 내용
### 필터링 기능 추가
- 카테고리 필터: 전체 / 핸드폰 / 태블릿 (라디오 버튼)
- 브랜드 필터: Apple / Samsung / 기타 (체크박스, 다중 선택)
- 가격 범위 필터: 최소가 ~ 최대가 (숫자 입력)


### 정렬 기능 추가
- 최신순 (created_at DESC)
- 인기순 (bid_count DESC)
- 마감임박순 (end_at ASC)
- 낮은가격순 (current_price ASC)
- 높은가격순 (current_price DESC)


### 검색 + 필터 통합
- 키워드 검색 + 필터 동시 적용 가능
- 페이지네이션에서 모든 파라미터 유지

