### PR TITLE
[260114] fix: 거래 자동 완료 처리시 조건 수정

### DIFF
--- a/src/main/java/kr/eolmago/repository/deal/DealRepository.java
+++ b/src/main/java/kr/eolmago/repository/deal/DealRepository.java
@@ -35,17 +35,6 @@ public interface DealRepository extends JpaRepository<Deal, Long>, DealRepositor
     List<Deal> findByStatusAndConfirmByAtBefore(DealStatus status, OffsetDateTime now);
 
     /**
-     * 자동 완료 대상 거래 목록 조회
-     *
-     * CONFIRMED 상태이면서, 배송 시작 후 일정 기간이 지난 거래 조회
-     *
-     * @param status 거래 상태 (CONFIRMED)
-     * @param threshold 기준 시간 (shippedAt이 이 시간보다 이전인 거래)
-     * @return 자동 완료 대상 거래 목록
-     */
-    List<Deal> findByStatusAndShippedAtBefore(DealStatus status, OffsetDateTime threshold);
-
-    /**
      * 특정 경매로 생성된 거래 존재 여부 확인
      *
      * 용도: 중복 생성 방지

--- a/src/main/java/kr/eolmago/repository/deal/DealRepositoryCustom.java
+++ b/src/main/java/kr/eolmago/repository/deal/DealRepositoryCustom.java
@@ -1,8 +1,11 @@
 package kr.eolmago.repository.deal;
 
+import kr.eolmago.domain.entity.deal.Deal;
 import kr.eolmago.dto.api.deal.response.DealDetailDto;
 import kr.eolmago.dto.api.deal.response.DealPdfDto;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -12,6 +15,7 @@ public interface DealRepositoryCustom {
 
     // 거래 상세 조회
     Optional<DealDetailDto> findDetailById(Long dealId);
+
     /**
      * PDF 생성을 위한 Deal 정보 조회
      *
@@ -22,4 +26,17 @@ public interface DealRepositoryCustom {
      * @return PDF 생성용 DTO
      */
     Optional<DealPdfDto> findPdfDataByDealId(Long dealId);
+
+    /**
+     * 자동 완료 가능한 거래 조회
+     *
+     * 조건:
+     * 1. CONFIRMED 상태
+     * 2. shippedAt이 threshold 이전 (배송 시작 후 N일 경과)
+     * 3. 해당 auction에 진행 중인 신고가 없음 (PENDING, UNDER_REVIEW 상태의 Report 없음)
+     *
+     * @param shippedAtThreshold 배송 시작 기준 시간 (이 시간보다 이전에 배송된 거래)
+     * @return 자동 완료 가능한 거래 목록
+     */
+    List<Deal> findCompletableDeals(OffsetDateTime shippedAtThreshold);
 }

--- a/src/test/java/kr/eolmago/scheduler/DealSchedulerTest.java
+++ b/src/test/java/kr/eolmago/scheduler/DealSchedulerTest.java
@@ -68,13 +68,13 @@ class DealSchedulerTest {
         // given
         Deal deal1 = mock(Deal.class);
         Deal deal2 = mock(Deal.class);
-        
+
         given(dealRepository.findByStatusAndConfirmByAtBefore(eq(DealStatus.PENDING_CONFIRMATION), any(OffsetDateTime.class)))
                 .willReturn(List.of(deal1, deal2));
-        
+
         given(deal1.getDealId()).willReturn(1L);
         given(deal2.getDealId()).willReturn(2L);
-        
+
         // deal1 처리 시 예외 발생
         doThrow(new RuntimeException("Error")).when(deal1).expire();
 
@@ -84,5 +84,61 @@ class DealSchedulerTest {
         // then
         verify(deal1, times(1)).expire();
         verify(deal2, times(1)).expire(); // deal1 실패와 무관하게 deal2는 실행되어야 함
+    }
+
+    @Test
+    @DisplayName("배송 시작 후 7일이 지나고 신고가 없는 거래는 자동으로 완료 처리된다")
+    void autoCompleteDeal_Success() {
+        // given
+        given(dealRepository.findCompletableDeals(any(OffsetDateTime.class)))
+                .willReturn(List.of(deal));
+
+        given(deal.getDealId()).willReturn(1L);
+        given(deal.getShippedAt()).willReturn(OffsetDateTime.now().minusDays(7));
+
+        // when
+        dealScheduler.autoCompleteDeal();
+
+        // then
+        verify(deal, times(1)).complete();
+    }
+
+    @Test
+    @DisplayName("자동 완료 대상 거래가 없으면 아무 작업도 하지 않는다")
+    void autoCompleteDeal_NoDeals() {
+        // given
+        given(dealRepository.findCompletableDeals(any(OffsetDateTime.class)))
+                .willReturn(Collections.emptyList());
+
+        // when
+        dealScheduler.autoCompleteDeal();
+
+        // then
+        verify(deal, never()).complete();
+    }
+
+    @Test
+    @DisplayName("거래 완료 처리 중 예외가 발생해도 다른 거래 처리에 영향을 주지 않는다")
+    void autoCompleteDeal_ExceptionHandling() {
+        // given
+        Deal deal1 = mock(Deal.class);
+        Deal deal2 = mock(Deal.class);
+
+        given(dealRepository.findCompletableDeals(any(OffsetDateTime.class)))
+                .willReturn(List.of(deal1, deal2));
+
+        given(deal1.getDealId()).willReturn(1L);
+        given(deal2.getDealId()).willReturn(2L);
+        given(deal2.getShippedAt()).willReturn(OffsetDateTime.now().minusDays(8));
+
+        // deal1 처리 시 예외 발생
+        doThrow(new RuntimeException("Error")).when(deal1).complete();
+
+        // when
+        dealScheduler.autoCompleteDeal();
+
+        // then
+        verify(deal1, times(1)).complete();
+        verify(deal2, times(1)).complete(); // deal1 실패와 무관하게 deal2는 실행되어야 함
     }
 }


### PR DESCRIPTION
## 이슈 번호
- Closes #136 

## 작업 내용
- DealRepositoryCustom에 findCompletableDeals() 메서드 추가
- DealRepositoryImpl에서 QueryDSL NOT EXISTS 서브쿼리로 구현:
 - CONFIRMED 상태
 - shipped_at + 7일 경과
 - 진행 중인 신고/분쟁 없음 (PENDING, UNDER_REVIEW 상태의 Report 없음)
- DealScheduler.autoCompleteDeal()에서 새로운 메서드 사용
- DealSchedulerTest 업데이트 (모킹 메서드명 변경)

