### PR TITLE
[260114] refactor: 검색API 기능 개선 및 테스트 코드 작성

### DIFF
--- a/src/main/java/kr/eolmago/controller/api/search/SearchApiController.java
+++ b/src/main/java/kr/eolmago/controller/api/search/SearchApiController.java
@@ -6,7 +6,6 @@ import kr.eolmago.dto.api.search.response.AutocompleteResponse;
 import kr.eolmago.dto.api.search.response.PopularKeywordResponse;
 import kr.eolmago.service.search.SearchKeywordService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/kr/eolmago/domain/entity/search/SearchKeyword.java
+++ b/src/main/java/kr/eolmago/domain/entity/search/SearchKeyword.java
@@ -60,11 +60,11 @@ public class SearchKeyword extends CreatedAtEntity {
      * @param keyword 검색어
      * @return KeywordType (BRAND, MODEL, GENERAL)
      */
-    private static KeywordType determineKeywordType(String keyword) {
+    public static KeywordType determineKeywordType(String keyword) {
         String lowerKeyword = keyword.toLowerCase();
 
         // 브랜드 키워드 (명세서에서 브랜드 가중치 +100 적용)
-        if (lowerKeyword.matches(".*(아이폰|갤럭시|픽셀|샤오미|apple|samsung|google|xiaomi).*")) {
+        if (lowerKeyword.matches(".*(아이폰|갤럭시|엘지|픽셀|샤오미|소니|모토로라|apple|samsung|lg|google|xiaomi|sony|motorola).*")) {
             return KeywordType.BRAND;
         }
 

--- a/src/main/java/kr/eolmago/dto/api/search/response/PopularKeywordResponse.java
+++ b/src/main/java/kr/eolmago/dto/api/search/response/PopularKeywordResponse.java
@@ -21,7 +21,7 @@ public record PopularKeywordResponse(
         Integer searchCount // 검색 횟수
 ) {
     /**
-     * SearchKeyword + 순위 → DTO 변환
+     * SearchKeyword + 순위 → DTO 변환 (DB 데이터)
      *
      * @param searchKeyword SearchKeyword 엔티티
      * @param rank 순위 (1부터 시작)
@@ -32,6 +32,22 @@ public record PopularKeywordResponse(
                 rank,
                 searchKeyword.getKeyword(),
                 searchKeyword.getSearchCount()
+        );
+    }
+
+    /**
+     * Redis 데이터 → DTO 변환
+     *
+     * @param keyword 검색어
+     * @param score Redis 점수 (searchCount + brandWeight)
+     * @param rank 순위 (1부터 시작)
+     * @return PopularKeywordResponse
+     */
+    public static PopularKeywordResponse ofRedis(String keyword, Double score, int rank) {
+        return new PopularKeywordResponse(
+                rank,
+                keyword,
+                score != null ? score.intValue() : 0
         );
     }
 }

--- a/src/main/java/kr/eolmago/repository/auction/impl/AuctionSearchRepositoryCustomImpl.java
+++ b/src/main/java/kr/eolmago/repository/auction/impl/AuctionSearchRepositoryCustomImpl.java
@@ -103,8 +103,12 @@ public class AuctionSearchRepositoryCustomImpl implements AuctionSearchRepositor
 
         // WHERE 절 생성
         String whereClause = buildWhereClause(category, brands, minPrice, maxPrice, status);
-        // item_name, title, description 모두 검색 대상에 포함
-        whereClause += "AND to_tsvector('simple', ai.item_name || ' ' || COALESCE(a.title, '') || ' ' || COALESCE(a.description, '')) @@ to_tsquery('simple', :processedKeyword) ";
+        // item_name, title 검색
+        whereClause += """
+            AND (
+                to_tsvector('simple', ai.item_name) @@ to_tsquery('simple', :processedKeyword)
+                OR to_tsvector('simple', COALESCE(a.title, '')) @@ to_tsquery('simple', :processedKeyword)
+            ) """;
 
         // ORDER BY 절 생성
         String orderBy = buildOrderBy(sort);

--- a/src/main/java/kr/eolmago/repository/search/SearchKeywordRepository.java
+++ b/src/main/java/kr/eolmago/repository/search/SearchKeywordRepository.java
@@ -9,10 +9,6 @@ import java.util.Optional;
 
 /**
  * 검색 키워드 Repository
- *
- * 역할:
- * - 간단한 조회: 메서드 이름 쿼리
- * - 복잡한 조회: QueryDSL (SearchKeywordRepositoryCustom)
  */
 public interface SearchKeywordRepository extends JpaRepository<SearchKeyword, Long>, SearchKeywordRepositoryCustom {
 

--- a/src/main/java/kr/eolmago/service/auction/AuctionSearchService.java
+++ b/src/main/java/kr/eolmago/service/auction/AuctionSearchService.java
@@ -20,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
+import static kr.eolmago.service.auction.constants.AuctionConstants.*;
+
 /**
  * 경매 통합 검색 Service
  *
@@ -307,17 +309,24 @@ public class AuctionSearchService {
 
     /**
      * 키워드 길이에 따라 동적으로 threshold 조정
+     *
+     * 로직:
+     * - 짧은 키워드 (≤2글자): 엄격한 임계값 (0.5)
+     * - 중간 키워드 (≤4글자): 중간 임계값 (0.3)
+     * - 긴 키워드 (5글자+): 관대한 임계값 (0.25)
+     *
+     * @param keyword 검색 키워드
+     * @return Trigram 유사도 임계값
      */
     private double getDynamicThreshold(String keyword) {
         int length = keyword.length();
-        System.out.println("length: " + length);
 
-        if (length <= 2) {
-            return 0.5;  // 짧은 키워드는 엄격하게
-        } else if (length <= 4) {
-            return 0.3;  // 중간 길이
+        if (length <= KEYWORD_LENGTH_SHORT) {
+            return TRIGRAM_THRESHOLD_SHORT;  // 짧은 키워드는 엄격하게
+        } else if (length <= KEYWORD_LENGTH_MEDIUM) {
+            return TRIGRAM_THRESHOLD_MEDIUM;  // 중간 길이
         } else {
-            return 0.25; // 긴 키워드는 관대하게
+            return TRIGRAM_THRESHOLD_LONG; // 긴 키워드는 관대하게
         }
     }
 

--- a/src/main/java/kr/eolmago/service/auction/constants/AuctionConstants.java
+++ b/src/main/java/kr/eolmago/service/auction/constants/AuctionConstants.java
@@ -14,4 +14,15 @@ public final class AuctionConstants {
     public static final int MAX_BID_AMOUNT = 10_000_000; // 입찰 금액 상한
     public static final int SWEEP_PAGE_SIZE = 500;
     public static final long RESULT_WAIT_POLL_MS = 50L;
+
+    // ==== 검색 ====
+    // Trigram 유사도 임계값
+    public static final double TRIGRAM_THRESHOLD_SHORT = 0.5;   // 짧은 키워드 (엄격)
+    public static final double TRIGRAM_THRESHOLD_MEDIUM = 0.3;  // 중간 길이
+    public static final double TRIGRAM_THRESHOLD_LONG = 0.25;   // 긴 키워드 (관대)
+
+    // 키워드 길이 기준
+    public static final int KEYWORD_LENGTH_SHORT = 2;   // 짧은 키워드 기준
+    public static final int KEYWORD_LENGTH_MEDIUM = 4;  // 중간 길이 키워드 기준
+
 }

--- a/src/main/java/kr/eolmago/service/search/SearchKeywordScheduler.java
+++ b/src/main/java/kr/eolmago/service/search/SearchKeywordScheduler.java
@@ -1,0 +1,63 @@
+package kr.eolmago.service.search;
+
+import kr.eolmago.domain.entity.search.SearchKeyword;
+import kr.eolmago.repository.search.SearchKeywordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SearchKeywordScheduler {
+
+    private final SearchKeywordRepository searchKeywordRepository;
+
+    /**
+     * 오래된 검색 키워드 정리 스케줄러
+     *  - (사용자량이 적은 시간) 매일 새벽 3시에 실행되어
+     *  - 3개월 이상 사용되지 않고 검색 횟수가 5회 미만인 키워드 자동 삭제
+     *
+     * 삭제 조건:
+     * - lastSearchedAt이 3개월 이전
+     * - searchCount가 5회 미만
+     */
+    @Scheduled(cron = "0 0 3 * * *")  // 매일 새벽 3시 (0분 0초)
+    @Transactional
+    public void cleanupInactiveKeywords() {
+        log.info("오래된 검색 키워드 정리 스케줄러 시작");
+
+        OffsetDateTime threshold = OffsetDateTime.now().minusMonths(3);  // 3개월 전
+        int minCount = 5;  // 5회 미만
+
+        // 비활성 키워드 조회
+        List<SearchKeyword> inactiveKeywords = searchKeywordRepository.findInactiveKeywords(threshold, minCount);
+
+        if (inactiveKeywords.isEmpty()) {
+            log.info("삭제할 검색 키워드가 없습니다.");
+            return;
+        }
+
+        log.info("삭제 대상 검색 키워드 건수: {}", inactiveKeywords.size());
+
+        int deletedCount = 0;
+        for (SearchKeyword keyword : inactiveKeywords) {
+            try {
+                searchKeywordRepository.delete(keyword);
+                deletedCount++;
+                log.debug("검색 키워드 삭제: keyword={}, searchCount={}, lastSearchedAt={}",
+                        keyword.getKeyword(), keyword.getSearchCount(), keyword.getLastSearchedAt());
+            } catch (Exception e) {
+                log.error("검색 키워드 삭제 실패: keyword={}, error={}",
+                        keyword.getKeyword(), e.getMessage());
+            }
+        }
+
+        log.info("오래된 검색 키워드 정리 완료. 삭제된 키워드 수: {}", deletedCount);
+    }
+}

--- a/src/main/java/kr/eolmago/service/search/constants/SearchConstants.java
+++ b/src/main/java/kr/eolmago/service/search/constants/SearchConstants.java
@@ -1,0 +1,27 @@
+package kr.eolmago.service.search.constants;
+
+/**
+ * 검색 관련 상수
+ */
+public final class SearchConstants {
+
+    // Redis Key 상수
+    public static final String AUTOCOMPLETE_KEY = "autocomplete:all"; // 전체 자동완성
+    public static final String SEARCH_DEDUPE_PREFIX = "search:dedupe:";  // 중복 방지
+
+    // ==== 자동완성 ====
+    public static final int AUTOCOMPLETE_LIMIT = 10;        // 자동완성 결과 개수
+    public static final int AUTOCOMPLETE_REDIS_TOP = 20;    // Redis에서 가져올 상위 개수
+    public static final int POPULAR_KEYWORDS_LIMIT = 10;    // 인기 검색어 개수
+
+    // ==== Redis 점수 계산 ====
+    public static final int BRAND_WEIGHT = 100;             // 브랜드 키워드 가중치
+    public static final double SEARCH_INCREMENT = 1.0;      // 검색 점수 증가량
+
+    // ==== 중복 방지 ====
+    public static final int SEARCH_DEDUPE_TTL_SECONDS = 10; // 중복 검색 방지 TTL (10초)
+
+    private SearchConstants() {
+        throw new AssertionError("Cannot instantiate constants class");
+    }
+}

--- a/src/test/java/kr/eolmago/repository/SearchKeywordRepositoryTest.java
+++ b/src/test/java/kr/eolmago/repository/SearchKeywordRepositoryTest.java
@@ -1,0 +1,162 @@
+package kr.eolmago.repository;
+
+import kr.eolmago.domain.entity.search.SearchKeyword;
+import kr.eolmago.repository.search.SearchKeywordRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SearchKeywordRepository 통합 테스트
+ *
+ * 목적:
+ * - DB Generated Column (keyword_chosung) 정상 작동 확인
+ * - 초성 검색 기능 검증
+ *
+ * 주의:
+ * - 초성 함수는 PostgreSQL 전용이므로 실제 DB 연결 필요
+ * - @SpringBootTest로 전체 컨텍스트 로드 (QueryDSL 포함)
+ */
+@SpringBootTest
+@Transactional
+class SearchKeywordRepositoryTest {
+
+    @Autowired
+    private SearchKeywordRepository searchKeywordRepository;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 데이터 초기화
+        searchKeywordRepository.deleteAll();
+        searchKeywordRepository.flush();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 테스트 데이터 정리
+        searchKeywordRepository.deleteAll();
+        searchKeywordRepository.flush();
+    }
+
+    @Test
+    @DisplayName("초성 검색: 'ㅇㅇㅍ' 검색 시 '아이폰' 키워드를 찾는다")
+    void findByChosungPrefix_Success() {
+        // given
+        SearchKeyword keyword1 = SearchKeyword.create("아이폰");  // ㅇㅇㅍ
+        SearchKeyword keyword2 = SearchKeyword.create("갤럭시");  // ㄱㄹㅅ
+        SearchKeyword keyword3 = SearchKeyword.create("아이패드"); // ㅇㅇㅍㄷ
+
+        searchKeywordRepository.save(keyword1);
+        searchKeywordRepository.save(keyword2);
+        searchKeywordRepository.save(keyword3);
+
+        // when
+        List<SearchKeyword> results = searchKeywordRepository.findByChosungPrefix("ㅇㅇㅍ", 10);
+
+        // then
+        assertThat(results).hasSize(2);  // 아이폰, 아이패드
+        assertThat(results).extracting(SearchKeyword::getKeyword)
+                .contains("아이폰");
+    }
+
+    @Test
+    @DisplayName("초성 검색: 'ㄱㄹ' 검색 시 '갤럭시', '구글' 키워드를 찾는다")
+    void findByChosungPrefix_Galaxy() {
+        // given
+        SearchKeyword keyword1 = SearchKeyword.create("아이폰");  // ㅇㅇㅍ
+        SearchKeyword keyword2 = SearchKeyword.create("갤럭시");  // ㄱㄹㅅ
+        SearchKeyword keyword3 = SearchKeyword.create("구글");   // ㄱㄱ
+
+        searchKeywordRepository.save(keyword1);
+        searchKeywordRepository.save(keyword2);
+        searchKeywordRepository.save(keyword3);
+
+        // when
+        List<SearchKeyword> results = searchKeywordRepository.findByChosungPrefix("ㄱㄹ", 10);
+
+        // then
+        assertThat(results).hasSize(1);  // 갤럭시만 (ㄱㄹㅅ는 ㄱㄹ로 시작)
+        assertThat(results.get(0).getKeyword()).isEqualTo("갤럭시");
+    }
+
+    @Test
+    @DisplayName("초성 검색: 검색 횟수 내림차순 정렬")
+    void findByChosungPrefix_OrderBySearchCount() {
+        // given
+        SearchKeyword keyword1 = SearchKeyword.create("아이폰");  // ㅇㅇㅍ
+        keyword1.incrementSearchCount();
+        keyword1.incrementSearchCount();  // searchCount = 3
+
+        SearchKeyword keyword2 = SearchKeyword.create("아이패드");  // ㅇㅇㅍㄷ, searchCount = 1
+
+        searchKeywordRepository.save(keyword1);
+        searchKeywordRepository.save(keyword2);
+
+        // when
+        List<SearchKeyword> results = searchKeywordRepository.findByChosungPrefix("ㅇㅇㅍ", 10);
+
+        // then
+        assertThat(results).hasSize(2);  // 아이폰(3), 아이패드(1)
+        assertThat(results.get(0).getKeyword()).isEqualTo("아이폰");  // searchCount 높은 순
+        assertThat(results.get(0).getSearchCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("초성 검색: 일치하는 결과가 없으면 빈 리스트 반환")
+    void findByChosungPrefix_NoResults() {
+        // given
+        SearchKeyword keyword = SearchKeyword.create("아이폰");  // ㅇㅇㅍ
+        searchKeywordRepository.save(keyword);
+
+        // when
+        List<SearchKeyword> results = searchKeywordRepository.findByChosungPrefix("ㅋㅋ", 10);
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("초성 검색: limit 제한 정상 작동")
+    void findByChosungPrefix_Limit() {
+        // given
+        for (int i = 1; i <= 5; i++) {
+            SearchKeyword keyword = SearchKeyword.create("아이폰" + i);  // ㅇㅇㅍ1, ㅇㅇㅍ2, ...
+            searchKeywordRepository.save(keyword);
+        }
+
+        // when
+        List<SearchKeyword> results = searchKeywordRepository.findByChosungPrefix("ㅇㅇㅍ", 3);
+
+        // then
+        assertThat(results).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("일반 prefix 검색: '아이' 검색 시 '아이폰' 키워드를 찾는다")
+    void findByKeywordPrefix_Success() {
+        // given
+        SearchKeyword keyword1 = SearchKeyword.create("아이폰");
+        SearchKeyword keyword2 = SearchKeyword.create("갤럭시");
+        SearchKeyword keyword3 = SearchKeyword.create("아이패드");
+
+        searchKeywordRepository.save(keyword1);
+        searchKeywordRepository.save(keyword2);
+        searchKeywordRepository.save(keyword3);
+
+        // when
+        List<SearchKeyword> results = searchKeywordRepository.findByKeywordPrefix("아이", 10);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(SearchKeyword::getKeyword)
+                .containsExactlyInAnyOrder("아이폰", "아이패드");
+    }
+}

--- a/src/test/java/kr/eolmago/scheduler/SearchKeywordSchedulerTest.java
+++ b/src/test/java/kr/eolmago/scheduler/SearchKeywordSchedulerTest.java
@@ -1,0 +1,89 @@
+package kr.eolmago.scheduler;
+
+import kr.eolmago.domain.entity.search.SearchKeyword;
+import kr.eolmago.repository.search.SearchKeywordRepository;
+import kr.eolmago.service.search.SearchKeywordScheduler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SearchKeywordSchedulerTest {
+
+    @InjectMocks
+    private SearchKeywordScheduler searchKeywordScheduler;
+
+    @Mock
+    private SearchKeywordRepository searchKeywordRepository;
+
+    @Mock
+    private SearchKeyword keyword;
+
+    @Test
+    @DisplayName("비활성 검색 키워드가 있으면 삭제 처리된다")
+    void cleanupInactiveKeywords_Success() {
+        // given
+        given(searchKeywordRepository.findInactiveKeywords(any(OffsetDateTime.class), anyInt()))
+                .willReturn(List.of(keyword));
+
+        given(keyword.getKeyword()).willReturn("test");
+        given(keyword.getSearchCount()).willReturn(3);
+        given(keyword.getLastSearchedAt()).willReturn(OffsetDateTime.now().minusMonths(4));
+
+        // when
+        searchKeywordScheduler.cleanupInactiveKeywords();
+
+        // then
+        verify(searchKeywordRepository, times(1)).delete(keyword);
+    }
+
+    @Test
+    @DisplayName("비활성 검색 키워드가 없으면 아무 작업도 하지 않는다")
+    void cleanupInactiveKeywords_NoKeywords() {
+        // given
+        given(searchKeywordRepository.findInactiveKeywords(any(OffsetDateTime.class), anyInt()))
+                .willReturn(Collections.emptyList());
+
+        // when
+        searchKeywordScheduler.cleanupInactiveKeywords();
+
+        // then
+        verify(searchKeywordRepository, never()).delete(any(SearchKeyword.class));
+    }
+
+    @Test
+    @DisplayName("키워드 삭제 중 예외가 발생해도 다른 키워드 처리에 영향을 주지 않는다")
+    void cleanupInactiveKeywords_ExceptionHandling() {
+        // given
+        SearchKeyword keyword1 = mock(SearchKeyword.class);
+        SearchKeyword keyword2 = mock(SearchKeyword.class);
+
+        given(searchKeywordRepository.findInactiveKeywords(any(OffsetDateTime.class), anyInt()))
+                .willReturn(List.of(keyword1, keyword2));
+
+        given(keyword1.getKeyword()).willReturn("test1");
+        given(keyword2.getKeyword()).willReturn("test2");
+
+        // keyword1 삭제 시 예외 발생
+        doThrow(new RuntimeException("Error")).when(searchKeywordRepository).delete(keyword1);
+
+        // when
+        searchKeywordScheduler.cleanupInactiveKeywords();
+
+        // then
+        verify(searchKeywordRepository, times(1)).delete(keyword1);
+        verify(searchKeywordRepository, times(1)).delete(keyword2); // keyword1 실패와 무관하게 keyword2는 실행되어야 함
+    }
+}


### PR DESCRIPTION
## 이슈 번호
- Closes #131 

## 작업 내용
 ### 1. 검색 코드 상수화 리팩토링
  - `SearchConstants` 클래스 생성: 검색 관련 매직넘버 상수화
    - Redis 키, 자동완성 제한, 브랜드 가중치, 중복 방지 TTL 등
  - `AuctionConstants` 검색 섹션 추가: Trigram 임계값, 키워드 길이 기준
  - `AuctionSearchService`, `SearchKeywordService` 상수 적용

  ### 2. 검색어 통계 동시성 이슈 해결
  - PostgreSQL UPSERT 쿼리로 변경 (INSERT ... ON CONFLICT DO UPDATE)
  - DB 레벨에서 원자적 처리하여 Race Condition 제거
  - `keyword_type` 판단 로직 중복 제거
    - SQL CASE 문 제거 → Java `SearchKeyword.determineKeywordType()` 재사용

  **수정 파일:**
  - `SearchKeywordRepositoryCustom`: upsertSearchCount(keyword, keywordType) 추가
  - `SearchKeywordRepositoryImpl`: Native Query 구현
  - `SearchKeyword`: determineKeywordType을 public static으로 변경
  - `SearchKeywordService`: updateDatabaseStatistics 단순화

  ### 3. 인기 검색어 Redis Fallback 패턴 적용
  - Redis 우선 조회 → 실패 시 DB Fallback
  - 성능 향상 (O(log N) vs Full Table Scan) 및 DB 부하 감소

  **수정 파일:**
  - `SearchKeywordService`: getPopularKeywords 개선
  - `PopularKeywordResponse`: ofRedis 메서드 추가

  ### 4. 코드 품질 개선
  - `isBrandKeyword()`: 문자열 비교 → Enum 직접 비교
  - KeywordType import 추가

### 5. 초성 자동완성 기능 구현
- 초성으로 검색 시 초성과 일반 검색을 구별하여 초성으로 검색 시 DB에서 조회, 일반 Full-Text 검색이면 Redis로 조회하게 수정

