### PR TITLE
[260505] test : 입찰 동시성 제어 정합성 검증 테스트 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.9'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'idea'
 }
 
 group = 'kr.eolmago'

--- a/src/test/java/kr/eolmago/config/TestSecurityConfig.java
+++ b/src/test/java/kr/eolmago/config/TestSecurityConfig.java
@@ -1,0 +1,25 @@
+package kr.eolmago.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+
+@TestConfiguration
+@EnableMethodSecurity
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/**").authenticated()
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+}

--- a/src/test/java/kr/eolmago/controller/api/auction/BidControllerTest.java
+++ b/src/test/java/kr/eolmago/controller/api/auction/BidControllerTest.java
@@ -1,0 +1,239 @@
+package kr.eolmago.controller.api.auction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.eolmago.config.TestSecurityConfig;
+import kr.eolmago.dto.api.auction.request.BidCreateRequest;
+import kr.eolmago.dto.api.auction.response.BidCreateResponse;
+import kr.eolmago.global.exception.BusinessException;
+import kr.eolmago.global.exception.ErrorCode;
+import kr.eolmago.global.exception.GlobalExceptionHandler;
+import kr.eolmago.global.security.CustomUserDetails;
+import kr.eolmago.service.auction.BidListService;
+import kr.eolmago.service.auction.BidService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+// HTTP 요청/응답, 인증, 유효성 검사 검증
+@WebMvcTest(BidController.class)
+@Import({TestSecurityConfig.class, GlobalExceptionHandler.class})
+@DisplayName("BidApiController API 테스트")
+class BidControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private BidService bidService;
+
+    @MockitoBean
+    private BidListService bidListService;
+
+    private final UUID auctionId = UUID.randomUUID();
+    private final UUID buyerId = UUID.randomUUID();
+
+    @Nested
+    @DisplayName("입찰 생성 (POST /api/auctions/{auctionId}/bids)")
+    class CreateBidTests {
+
+        @Test
+        @DisplayName("정상 입찰 시 201 CREATED 응답")
+        void givenValidRequest_whenCreateBid_thenReturn201() throws Exception {
+            // Given
+            int amount = 15000;
+            String clientRequestId = "req-" + UUID.randomUUID();
+            BidCreateRequest request = new BidCreateRequest(amount, clientRequestId);
+
+            BidCreateResponse response = new BidCreateResponse(
+                    1L, auctionId, amount, amount, amount + 1000,
+                    OffsetDateTime.now().plusHours(1), false, buyerId
+            );
+
+            when(bidService.createBid(eq(auctionId), any(BidCreateRequest.class), any(UUID.class)))
+                    .thenReturn(response);
+
+            // When & Then
+            mockMvc.perform(post("/api/auctions/{auctionId}/bids", auctionId)
+                            .with(user(createMockPrincipal(buyerId)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.bidId").value(1))
+                    .andExpect(jsonPath("$.auctionId").value(auctionId.toString()))
+                    .andExpect(jsonPath("$.acceptedAmount").value(amount));
+        }
+
+        @Test
+        @DisplayName("clientRequestId 누락 시 400 BAD_REQUEST")
+        void givenMissingClientRequestId_whenCreateBid_thenReturn400() throws Exception {
+            // Given: clientRequestId가 null인 요청 (직접 JSON 작성)
+            String invalidJson = """
+                    {
+                        "amount": 15000
+                    }
+                    """;
+
+            // When & Then
+            mockMvc.perform(post("/api/auctions/{auctionId}/bids", auctionId)
+                            .with(user(createMockPrincipal(buyerId)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(invalidJson))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("clientRequestId 길이 부족 시 400 BAD_REQUEST")
+        void givenShortClientRequestId_whenCreateBid_thenReturn400() throws Exception {
+            // Given
+            BidCreateRequest request = new BidCreateRequest(15000, "short");
+
+            // When & Then
+            mockMvc.perform(post("/api/auctions/{auctionId}/bids", auctionId)
+                            .with(user(createMockPrincipal(buyerId)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증 없이 요청 시 401/403 응답")
+        void givenNoAuthentication_whenCreateBid_thenReturnUnauthorized() throws Exception {
+            // Given
+            BidCreateRequest request = new BidCreateRequest(15000, "req-" + UUID.randomUUID());
+
+            // When & Then
+            mockMvc.perform(post("/api/auctions/{auctionId}/bids", auctionId)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().is4xxClientError()); // 401 또는 403
+        }
+
+        @Test
+        @DisplayName("AUCTION_NOT_LIVE 예외 시 400 BAD_REQUEST")
+        void givenAuctionNotLive_whenCreateBid_thenReturn400() throws Exception {
+            // Given
+            BidCreateRequest request = new BidCreateRequest(15000, "req-" + UUID.randomUUID());
+
+            when(bidService.createBid(any(), any(), any()))
+                    .thenThrow(new BusinessException(ErrorCode.AUCTION_NOT_LIVE));
+
+            // When & Then
+            mockMvc.perform(post("/api/auctions/{auctionId}/bids", auctionId)
+                            .with(user(createMockPrincipal(buyerId)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("A004"));
+        }
+
+        @Test
+        @DisplayName("AUCTION_LOCK_BUSY 예외 시 409 CONFLICT")
+        void givenLockBusy_whenCreateBid_thenReturn409() throws Exception {
+            // Given
+            BidCreateRequest request = new BidCreateRequest(15000, "req-" + UUID.randomUUID());
+
+            when(bidService.createBid(any(), any(), any()))
+                    .thenThrow(new BusinessException(ErrorCode.AUCTION_LOCK_BUSY));
+
+            // When & Then
+            mockMvc.perform(post("/api/auctions/{auctionId}/bids", auctionId)
+                            .with(user(createMockPrincipal(buyerId)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("B010"));
+        }
+
+        @Test
+        @DisplayName("BID_IDEMPOTENCY_CONFLICT 예외 시 409 CONFLICT")
+        void givenIdempotencyConflict_whenCreateBid_thenReturn409() throws Exception {
+            // Given
+            BidCreateRequest request = new BidCreateRequest(15000, "req-" + UUID.randomUUID());
+
+            when(bidService.createBid(any(), any(), any()))
+                    .thenThrow(new BusinessException(ErrorCode.BID_IDEMPOTENCY_CONFLICT));
+
+            // When & Then
+            mockMvc.perform(post("/api/auctions/{auctionId}/bids", auctionId)
+                            .with(user(createMockPrincipal(buyerId)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("B008"));
+        }
+    }
+
+    @Nested
+    @DisplayName("권한 검증")
+    class AuthorizationTests {
+
+        @Test
+        @WithMockUser(roles = "GUEST")
+        @DisplayName("GUEST 권한으로 입찰 시도 시 403 FORBIDDEN")
+        void givenGuestRole_whenCreateBid_thenReturn403() throws Exception {
+            // Given
+            BidCreateRequest request = new BidCreateRequest(15000, "req-" + UUID.randomUUID());
+
+            // When & Then
+            mockMvc.perform(post("/api/auctions/{auctionId}/bids", auctionId)
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("USER 권한으로 입찰 가능")
+        void givenUserRole_whenCreateBid_thenAllowed() throws Exception {
+            // Given
+            BidCreateRequest request = new BidCreateRequest(15000, "req-" + UUID.randomUUID());
+            BidCreateResponse response = new BidCreateResponse(
+                    1L, auctionId, 15000, 15000, 16000,
+                    OffsetDateTime.now().plusHours(1), false, buyerId
+            );
+
+            when(bidService.createBid(any(), any(), any())).thenReturn(response);
+
+            // When & Then
+            mockMvc.perform(post("/api/auctions/{auctionId}/bids", auctionId)
+                            .with(user(createMockPrincipal(buyerId)))
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated());
+        }
+    }
+
+    private CustomUserDetails createMockPrincipal(UUID userId) {
+        CustomUserDetails principal = mock(CustomUserDetails.class);
+        when(principal.getId()).thenReturn(userId.toString());
+        when(principal.getAuthorities()).thenReturn(java.util.Collections.emptyList());
+        return principal;
+    }
+}

--- a/src/test/java/kr/eolmago/service/auction/AuctionCloseSchedulerTest.java
+++ b/src/test/java/kr/eolmago/service/auction/AuctionCloseSchedulerTest.java
@@ -1,0 +1,343 @@
+package kr.eolmago.service.auction;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.global.config.properties.AuctionRuntimeProperties;
+import kr.eolmago.service.auction.monitoring.AuctionCloseMetricsRecorder;
+import kr.eolmago.dto.view.auction.AuctionEndAtView;
+import kr.eolmago.repository.auction.AuctionCloseRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.TaskScheduler;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+// 경매 종료 스케줄링 로직 검증
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuctionCloseScheduler 단위 테스트")
+class AuctionCloseSchedulerTest {
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private AuctionCloseService auctionCloseService;
+
+    @Mock
+    private AuctionCloseRepository auctionCloseRepository;
+
+    private AuctionCloseScheduler sut;
+
+    @BeforeEach
+    void setUp() {
+        AuctionRuntimeProperties properties = new AuctionRuntimeProperties();
+        sut = new AuctionCloseScheduler(
+                taskScheduler,
+                auctionCloseService,
+                auctionCloseRepository,
+                properties,
+                new AuctionCloseMetricsRecorder(new SimpleMeterRegistry())
+        );
+    }
+
+    @Nested
+    @DisplayName("스케줄 등록/재등록")
+    class ScheduleOrRescheduleTests {
+
+        @Test
+        @DisplayName("새 경매 스케줄 등록 성공")
+        void givenNewAuction_whenSchedule_thenTaskScheduled() {
+            // Given
+            UUID auctionId = UUID.randomUUID();
+            OffsetDateTime endAt = OffsetDateTime.now().plusHours(1);
+            @SuppressWarnings("unchecked")
+            ScheduledFuture<?> mockFuture = mock(ScheduledFuture.class);
+
+            doReturn(mockFuture).when(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
+
+            // When
+            sut.scheduleOrReschedule(auctionId, endAt);
+
+            // Then
+            ArgumentCaptor<Instant> instantCaptor = ArgumentCaptor.forClass(Instant.class);
+            verify(taskScheduler).schedule(any(Runnable.class), instantCaptor.capture());
+
+            Instant scheduledAt = instantCaptor.getValue();
+            assertThat(scheduledAt).isEqualTo(endAt.toInstant());
+        }
+
+        @Test
+        @DisplayName("기존 스케줄 재등록 시 이전 future 취소")
+        void givenExistingSchedule_whenReschedule_thenCancelPreviousAndScheduleNew() {
+            // Given
+            UUID auctionId = UUID.randomUUID();
+            OffsetDateTime firstEndAt = OffsetDateTime.now().plusHours(1);
+            OffsetDateTime secondEndAt = OffsetDateTime.now().plusHours(2);
+
+            @SuppressWarnings("unchecked")
+            ScheduledFuture<?> firstFuture = mock(ScheduledFuture.class);
+            @SuppressWarnings("unchecked")
+            ScheduledFuture<?> secondFuture = mock(ScheduledFuture.class);
+
+            doReturn(firstFuture, secondFuture)
+                    .when(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
+
+            // When: 첫 번째 등록
+            sut.scheduleOrReschedule(auctionId, firstEndAt);
+            // When: 같은 경매 재등록
+            sut.scheduleOrReschedule(auctionId, secondEndAt);
+
+            // Then: 첫 번째 future가 취소되어야 함
+            verify(firstFuture).cancel(false);
+            verify(taskScheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
+        }
+
+        @Test
+        @DisplayName("과거 시간으로 스케줄 시 즉시 실행 (현재 시간으로 조정)")
+        void givenPastEndAt_whenSchedule_thenScheduleAtNow() {
+            // Given
+            UUID auctionId = UUID.randomUUID();
+            OffsetDateTime pastEndAt = OffsetDateTime.now().minusHours(1);
+            @SuppressWarnings("unchecked")
+            ScheduledFuture<?> mockFuture = mock(ScheduledFuture.class);
+
+            doReturn(mockFuture).when(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
+
+            // When
+            sut.scheduleOrReschedule(auctionId, pastEndAt);
+
+            // Then
+            ArgumentCaptor<Instant> instantCaptor = ArgumentCaptor.forClass(Instant.class);
+            verify(taskScheduler).schedule(any(Runnable.class), instantCaptor.capture());
+
+            // 스케줄 시간이 과거가 아니어야 함
+            Instant scheduledAt = instantCaptor.getValue();
+            assertThat(scheduledAt).isAfterOrEqualTo(Instant.now().minusSeconds(1));
+        }
+
+        @Test
+        @DisplayName("null auctionId 또는 endAt이면 무시")
+        void givenNullParams_whenSchedule_thenIgnore() {
+            // When
+            sut.scheduleOrReschedule(null, OffsetDateTime.now());
+            sut.scheduleOrReschedule(UUID.randomUUID(), null);
+
+            // Then
+            verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
+        }
+
+        @Test
+        @DisplayName("TaskScheduler.schedule()이 null 반환 시 정상 처리")
+        void givenSchedulerReturnsNull_whenSchedule_thenHandleGracefully() {
+            // Given
+            UUID auctionId = UUID.randomUUID();
+            OffsetDateTime endAt = OffsetDateTime.now().plusHours(1);
+
+            doReturn(null).when(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
+
+            // When & Then: 예외 없이 완료되어야 함
+            assertThatCode(() -> sut.scheduleOrReschedule(auctionId, endAt))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("TaskRejectedException 발생 시 정상 처리")
+        void givenTaskRejected_whenSchedule_thenHandleGracefully() {
+            // Given
+            UUID auctionId = UUID.randomUUID();
+            OffsetDateTime endAt = OffsetDateTime.now().plusHours(1);
+
+            doThrow(new TaskRejectedException("Queue full"))
+                    .when(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
+
+            // When & Then
+            assertThatCode(() -> sut.scheduleOrReschedule(auctionId, endAt))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("부트스트랩")
+    class BootstrapTests {
+
+        @Test
+        @DisplayName("서버 시작 시 LIVE 경매들 재등록")
+        void givenLiveAuctions_whenBootstrap_thenRescheduleAll() {
+            // Given
+            UUID auction1 = UUID.randomUUID();
+            UUID auction2 = UUID.randomUUID();
+            OffsetDateTime endAt1 = OffsetDateTime.now().plusHours(1);
+            OffsetDateTime endAt2 = OffsetDateTime.now().plusHours(2);
+
+            List<AuctionEndAtView> liveAuctions = Arrays.asList(
+                    new AuctionEndAtView(auction1, endAt1),
+                    new AuctionEndAtView(auction2, endAt2)
+            );
+
+            when(auctionCloseRepository.findAllEndAtByStatus(AuctionStatus.LIVE))
+                    .thenReturn(liveAuctions);
+            @SuppressWarnings("unchecked")
+            ScheduledFuture<?> mockFuture = mock(ScheduledFuture.class);
+            doReturn(mockFuture).when(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
+
+            // When
+            sut.bootstrapOnStartup();
+
+            // Then: 2개의 경매가 스케줄됨
+            verify(taskScheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
+        }
+
+        @Test
+        @DisplayName("LIVE 경매 없으면 스케줄 없음")
+        void givenNoLiveAuctions_whenBootstrap_thenNoScheduling() {
+            // Given
+            when(auctionCloseRepository.findAllEndAtByStatus(AuctionStatus.LIVE))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            sut.bootstrapOnStartup();
+
+            // Then
+            verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
+        }
+
+        @Test
+        @DisplayName("부트스트랩 중 예외 발생해도 서버 시작 계속")
+        void givenExceptionDuringBootstrap_thenContinue() {
+            // Given
+            doThrow(new RuntimeException("DB connection failed"))
+                    .when(auctionCloseRepository).findAllEndAtByStatus(AuctionStatus.LIVE);
+
+            // When & Then
+            assertThatCode(() -> sut.bootstrapOnStartup())
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("오버듀 스윕")
+    class SweepTests {
+
+        @Test
+        @DisplayName("오버듀 경매들 종료 처리")
+        void givenOverdueAuctions_whenSweep_thenCloseAll() {
+            // Given
+            UUID auction1 = UUID.randomUUID();
+            UUID auction2 = UUID.randomUUID();
+            List<UUID> overdueIds = Arrays.asList(auction1, auction2);
+
+            when(auctionCloseRepository.findIdsToClose(eq(AuctionStatus.LIVE), any(OffsetDateTime.class), any(PageRequest.class)))
+                    .thenReturn(overdueIds);
+
+            // When
+            sut.sweepOverdueAuctions();
+
+            // Then
+            verify(auctionCloseService).closeAuction(auction1);
+            verify(auctionCloseService).closeAuction(auction2);
+        }
+
+        @Test
+        @DisplayName("오버듀 경매 없으면 종료 호출 없음")
+        void givenNoOverdueAuctions_whenSweep_thenNoClose() {
+            // Given
+            when(auctionCloseRepository.findIdsToClose(any(), any(), any()))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            sut.sweepOverdueAuctions();
+
+            // Then
+            verify(auctionCloseService, never()).closeAuction(any());
+        }
+
+        @Test
+        @DisplayName("개별 종료 실패해도 다른 경매 처리 계속")
+        void givenCloseFailsForOne_whenSweep_thenContinueWithOthers() {
+            // Given
+            UUID auction1 = UUID.randomUUID();
+            UUID auction2 = UUID.randomUUID();
+            UUID auction3 = UUID.randomUUID();
+            List<UUID> overdueIds = Arrays.asList(auction1, auction2, auction3);
+
+            when(auctionCloseRepository.findIdsToClose(any(), any(), any()))
+                    .thenReturn(overdueIds);
+            doThrow(new RuntimeException("Close failed"))
+                    .when(auctionCloseService).closeAuction(auction2);
+
+            // When
+            sut.sweepOverdueAuctions();
+
+            // Then: 모든 경매에 대해 closeAuction 시도
+            verify(auctionCloseService).closeAuction(auction1);
+            verify(auctionCloseService).closeAuction(auction2);
+            verify(auctionCloseService).closeAuction(auction3);
+        }
+    }
+
+    @Nested
+    @DisplayName("실행된 태스크 동작 검증")
+    class ScheduledTaskExecutionTests {
+
+        @Test
+        @DisplayName("스케줄된 태스크 실행 시 closeAuction 호출")
+        void givenScheduledTask_whenExecuted_thenCallCloseAuction() {
+            // Given
+            UUID auctionId = UUID.randomUUID();
+            OffsetDateTime endAt = OffsetDateTime.now().plusHours(1);
+
+            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+            @SuppressWarnings("unchecked")
+            ScheduledFuture<?> mockFuture = mock(ScheduledFuture.class);
+            doReturn(mockFuture).when(taskScheduler).schedule(taskCaptor.capture(), any(Instant.class));
+
+            sut.scheduleOrReschedule(auctionId, endAt);
+
+            // When: 캡처된 태스크 실행
+            Runnable scheduledTask = taskCaptor.getValue();
+            scheduledTask.run();
+
+            // Then
+            verify(auctionCloseService).closeAuction(auctionId);
+        }
+
+        @Test
+        @DisplayName("closeAuction 예외 시에도 태스크 정상 완료")
+        void givenCloseAuctionThrows_whenTaskExecuted_thenCompleteGracefully() {
+            // Given
+            UUID auctionId = UUID.randomUUID();
+            OffsetDateTime endAt = OffsetDateTime.now().plusHours(1);
+
+            ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+            @SuppressWarnings("unchecked")
+            ScheduledFuture<?> mockFuture = mock(ScheduledFuture.class);
+            doReturn(mockFuture).when(taskScheduler).schedule(taskCaptor.capture(), any(Instant.class));
+            doThrow(new RuntimeException("Close failed"))
+                    .when(auctionCloseService).closeAuction(auctionId);
+
+            sut.scheduleOrReschedule(auctionId, endAt);
+
+            // When & Then: 예외 없이 완료
+            Runnable scheduledTask = taskCaptor.getValue();
+            assertThatCode(scheduledTask::run).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/kr/eolmago/service/auction/AuctionCloseServiceTest.java
+++ b/src/test/java/kr/eolmago/service/auction/AuctionCloseServiceTest.java
@@ -1,0 +1,277 @@
+package kr.eolmago.service.auction;
+
+import kr.eolmago.domain.entity.auction.Auction;
+import kr.eolmago.domain.entity.auction.Bid;
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.domain.entity.user.User;
+import kr.eolmago.global.exception.BusinessException;
+import kr.eolmago.global.exception.ErrorCode;
+import kr.eolmago.repository.auction.*;
+import kr.eolmago.repository.user.UserRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import kr.eolmago.service.auction.event.AuctionSoldEvent;
+import kr.eolmago.service.auction.monitoring.AuctionCloseMetricsRecorder;
+import kr.eolmago.service.auction.monitoring.AuctionLockFailureDetector;
+import kr.eolmago.service.notification.publish.NotificationPublishCommand;
+import kr.eolmago.service.notification.publish.NotificationPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static kr.eolmago.service.auction.BidTestFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+// 경매 종료 시 낙찰/유찰 처리 로직 검증
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuctionCloseService 단위 테스트")
+class AuctionCloseServiceTest {
+
+    @Mock
+    private AuctionCloseRepository auctionCloseRepository;
+
+    @Mock
+    private BidRepository bidRepository;
+
+    @Mock
+    private AuctionItemRepository auctionItemRepository;
+
+    @Mock
+    private AuctionImageRepository auctionImageRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationPublisher notificationPublisher;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private AuctionCloseService sut;
+
+    private final UUID auctionId = generateAuctionId();
+    private final UUID sellerId = generateUserId();
+    private final UUID buyerId = generateUserId();
+
+    @BeforeEach
+    void setUp() {
+        sut = new AuctionCloseService(
+                auctionCloseRepository, bidRepository,
+                auctionItemRepository, auctionImageRepository, userRepository,
+                notificationPublisher, eventPublisher,
+                new AuctionCloseMetricsRecorder(new SimpleMeterRegistry()),
+                new AuctionLockFailureDetector()
+        );
+    }
+
+    @Nested
+    @DisplayName("경매 종료 처리")
+    class CloseAuctionTests {
+
+        @Test
+        @DisplayName("입찰 없는 LIVE 경매 종료 시 ENDED_UNSOLD 처리 및 유찰 알림 발행")
+        void givenLiveAuctionWithNoBids_whenClose_thenMarkAsUnsoldAndNotify() {
+            // Given
+            Auction auction = createMockLiveAuction(auctionId, sellerId);
+            when(auction.getEndAt()).thenReturn(OffsetDateTime.now().minusMinutes(1)); // 이미 종료 시간 지남
+
+            when(auctionCloseRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+            when(bidRepository.findTopByAuctionOrderByAmountDescCreatedAtAsc(auction))
+                    .thenReturn(Optional.empty());
+
+            // When
+            sut.closeAuction(auctionId);
+
+            // Then
+            verify(auction).closeAsUnsold();
+            verify(notificationPublisher).publish(any(NotificationPublishCommand.class));
+        }
+
+        @Test
+        @DisplayName("입찰 있는 LIVE 경매 종료 시 ENDED_SOLD 처리 및 낙찰 알림/이벤트 발행")
+        void givenLiveAuctionWithBids_whenClose_thenMarkAsSoldAndNotifyBothParties() {
+            // Given
+            Auction auction = createMockLiveAuction(auctionId, sellerId);
+            when(auction.getEndAt()).thenReturn(OffsetDateTime.now().minusMinutes(1));
+
+            User buyer = createMockUser(buyerId);
+            int finalAmount = 50000;
+            Bid highestBid = createMockBid(auction, buyer, finalAmount, "req-highest");
+
+            when(auctionCloseRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+            when(bidRepository.findTopByAuctionOrderByAmountDescCreatedAtAsc(auction))
+                    .thenReturn(Optional.of(highestBid));
+
+            // When
+            sut.closeAuction(auctionId);
+
+            // Then
+            verify(auction).closeAsSold(buyer, (long) finalAmount);
+
+            // 판매자 + 구매자에게 알림 발행 (2회)
+            verify(notificationPublisher, times(2)).publish(any(NotificationPublishCommand.class));
+
+            // AuctionSoldEvent 발행
+            ArgumentCaptor<AuctionSoldEvent> eventCaptor = ArgumentCaptor.forClass(AuctionSoldEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+            AuctionSoldEvent event = eventCaptor.getValue();
+            assertThat(event.auctionId()).isEqualTo(auctionId);
+            assertThat(event.sellerId()).isEqualTo(sellerId);
+            assertThat(event.buyerId()).isEqualTo(buyerId);
+        }
+
+        @Test
+        @DisplayName("이미 종료된 경매에 중복 close 호출해도 안전")
+        void givenAlreadyClosedAuction_whenClose_thenDoNothing() {
+            // Given
+            Auction auction = mock(Auction.class);
+            when(auction.getStatus()).thenReturn(AuctionStatus.ENDED_SOLD);
+            when(auctionCloseRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When
+            sut.closeAuction(auctionId);
+
+            // Then: 아무 상태 변경도 없어야 함
+            verify(auction, never()).closeAsSold(any(), anyLong());
+            verify(auction, never()).closeAsUnsold();
+            verify(notificationPublisher, never()).publish(any());
+        }
+
+        @Test
+        @DisplayName("종료 시간이 아직 안 된 경매는 종료되지 않음")
+        void givenAuctionNotYetEnded_whenClose_thenDoNothing() {
+            // Given
+            Auction auction = createMockLiveAuction(auctionId, sellerId);
+            when(auction.getEndAt()).thenReturn(OffsetDateTime.now().plusHours(1)); // 아직 1시간 남음
+
+            when(auctionCloseRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When
+            sut.closeAuction(auctionId);
+
+            // Then
+            verify(auction, never()).closeAsSold(any(), anyLong());
+            verify(auction, never()).closeAsUnsold();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 경매 종료 시도 시 AUCTION_NOT_FOUND")
+        void givenNonExistentAuction_whenClose_thenThrowNotFound() {
+            // Given
+            when(auctionCloseRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> sut.closeAuction(auctionId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("판매자 경매 취소")
+    class CancelAuctionBySellerTests {
+
+        @Test
+        @DisplayName("입찰 없는 LIVE 경매 취소 성공")
+        void givenLiveAuctionWithNoBids_whenCancel_thenSuccess() {
+            // Given
+            Auction auction = createMockLiveAuction(auctionId, sellerId);
+            when(auction.getBidCount()).thenReturn(0);
+
+            when(auctionCloseRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+            when(bidRepository.existsByAuction(auction)).thenReturn(false);
+
+            // When
+            sut.cancelAuctionBySeller(auctionId, sellerId);
+
+            // Then
+            verify(auction).cancelBySeller();
+            verify(notificationPublisher).publish(any(NotificationPublishCommand.class));
+        }
+
+        @Test
+        @DisplayName("입찰 있는 경매 취소 시도 시 AUCTION_HAS_ACTIVE_BIDS")
+        void givenAuctionWithBids_whenCancel_thenThrowHasActiveBids() {
+            // Given
+            Auction auction = createMockLiveAuction(auctionId, sellerId);
+            when(auction.getBidCount()).thenReturn(5);
+
+            when(auctionCloseRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.cancelAuctionBySeller(auctionId, sellerId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_HAS_ACTIVE_BIDS);
+        }
+
+        @Test
+        @DisplayName("다른 판매자가 취소 시도 시 AUCTION_UNAUTHORIZED")
+        void givenDifferentSeller_whenCancel_thenThrowUnauthorized() {
+            // Given
+            UUID otherSellerId = generateUserId();
+            Auction auction = createMockLiveAuction(auctionId, sellerId);
+
+            when(auctionCloseRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.cancelAuctionBySeller(auctionId, otherSellerId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("LIVE가 아닌 경매 취소 시도 시 AUCTION_NOT_LIVE")
+        void givenNonLiveAuction_whenCancel_thenThrowNotLive() {
+            // Given
+            Auction auction = mock(Auction.class);
+            User seller = createMockUser(sellerId);
+            when(auction.getSeller()).thenReturn(seller);
+            when(auction.getStatus()).thenReturn(AuctionStatus.DRAFT);
+
+            when(auctionCloseRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.cancelAuctionBySeller(auctionId, sellerId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_NOT_LIVE);
+        }
+    }
+
+    private Auction createMockLiveAuction(UUID auctionId, UUID sellerId) {
+        Auction auction = mock(Auction.class);
+        User seller = createMockUser(sellerId);
+
+        when(auction.getAuctionId()).thenReturn(auctionId);
+        when(auction.getStatus()).thenReturn(AuctionStatus.LIVE);
+        when(auction.getSeller()).thenReturn(seller);
+
+        return auction;
+    }
+}

--- a/src/test/java/kr/eolmago/service/auction/BidCommandServiceTest.java
+++ b/src/test/java/kr/eolmago/service/auction/BidCommandServiceTest.java
@@ -1,0 +1,502 @@
+package kr.eolmago.service.auction;
+
+import jakarta.persistence.LockTimeoutException;
+import jakarta.persistence.PessimisticLockException;
+import kr.eolmago.domain.entity.auction.Auction;
+import kr.eolmago.domain.entity.auction.Bid;
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.domain.entity.user.User;
+import kr.eolmago.dto.api.auction.response.BidCreateResponse;
+import kr.eolmago.global.exception.BusinessException;
+import kr.eolmago.global.exception.ErrorCode;
+import kr.eolmago.repository.auction.AuctionRepository;
+import kr.eolmago.repository.auction.BidRepository;
+import kr.eolmago.repository.user.UserRepository;
+import kr.eolmago.service.auction.event.AuctionEndAtChangedEvent;
+import kr.eolmago.service.auction.monitoring.BidMetricsRecorder;
+import kr.eolmago.service.auction.monitoring.AuctionBidAuditLogger;
+import kr.eolmago.service.auction.monitoring.AuctionLockFailureDetector;
+import kr.eolmago.service.notification.publish.NotificationPublishCommand;
+import kr.eolmago.service.notification.publish.NotificationPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static kr.eolmago.service.auction.BidTestFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+// 비즈니스 규칙 검증, 락 예외 처리, 알림/이벤트 발행 검증
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BidCommandService 단위 테스트")
+class BidCommandServiceTest {
+
+    @Mock
+    private AuctionRepository auctionRepository;
+
+    @Mock
+    private BidRepository bidRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private NotificationPublisher notificationPublisher;
+
+    private BidCommandService sut;
+
+    private final UUID auctionId = generateAuctionId();
+    private final UUID buyerId = generateUserId();
+    private final UUID sellerId = generateUserId();
+    private final String clientRequestId = generateClientRequestId();
+
+    @BeforeEach
+    void setUp() {
+        TransactionTemplate bidWriteTransactionTemplate = new TransactionTemplate(new TestTransactionManager());
+        bidWriteTransactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        bidWriteTransactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED);
+        bidWriteTransactionTemplate.setReadOnly(false);
+        bidWriteTransactionTemplate.setTimeout(3);
+        bidWriteTransactionTemplate.setName("test-auction-bid-write-tx");
+
+        sut = new BidCommandService(
+                auctionRepository, bidRepository, userRepository,
+                eventPublisher, notificationPublisher,
+                new BidMetricsRecorder(new SimpleMeterRegistry()),
+                new AuctionLockFailureDetector(),
+                new AuctionBidAuditLogger(),
+                bidWriteTransactionTemplate
+        );
+
+        lenient().when(bidRepository.saveAndFlush(any(Bid.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Nested
+    @DisplayName("경매 존재 여부 검증")
+    class AuctionExistenceValidation {
+
+        @Test
+        @DisplayName("경매가 없으면 AUCTION_NOT_FOUND 발생")
+        void givenAuctionNotFound_whenCreateBid_thenThrowNotFound() {
+            // Given
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 15000, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("경매 상태 검증")
+    class AuctionStatusValidation {
+
+        @ParameterizedTest
+        @EnumSource(value = AuctionStatus.class, names = {"DRAFT", "ENDED_SOLD", "ENDED_UNSOLD"})
+        @DisplayName("LIVE가 아닌 경매에 입찰하면 AUCTION_NOT_LIVE 발생")
+        void givenAuctionNotLive_whenCreateBid_thenThrowNotLive(AuctionStatus status) {
+            // Given
+            Auction auction = createMockAuction(auctionId, sellerId, status);
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 15000, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_NOT_LIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("판매자 입찰 금지")
+    class SellerBidProhibition {
+
+        @Test
+        @DisplayName("판매자가 자기 경매에 입찰하면 SELLER_CANNOT_BID 발생")
+        void givenSellerBid_whenCreateBid_thenThrowSellerCannotBid() {
+            // Given
+            Auction auction = createMockAuction(auctionId, sellerId, AuctionStatus.LIVE);
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, sellerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When & Then (sellerId == buyerId)
+            assertThatThrownBy(() -> sut.createBid(auctionId, sellerId, 15000, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.SELLER_CANNOT_BID);
+        }
+    }
+
+    @Nested
+    @DisplayName("입찰 금액 검증")
+    class BidAmountValidation {
+
+        @Test
+        @DisplayName("최소 입찰가 미만이면 BID_INVALID_AMOUNT 발생")
+        void givenAmountBelowMinimum_whenCreateBid_thenThrowInvalidAmount() {
+            // Given: currentPrice=10000, increment=1000 -> minAcceptable=11000
+            Auction auction = createMockAuction(auctionId, sellerId, AuctionStatus.LIVE,
+                    DEFAULT_START_PRICE, DEFAULT_BID_INCREMENT);
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When & Then: 10500 < 11000 (minAcceptable)
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 10500, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.BID_INVALID_AMOUNT);
+        }
+
+        @Test
+        @DisplayName("입찰 단위에 맞지 않으면 BID_INVALID_INCREMENT 발생")
+        void givenInvalidIncrement_whenCreateBid_thenThrowInvalidIncrement() {
+            // Given: currentPrice=10000, increment=1000
+            Auction auction = createMockAuction(auctionId, sellerId, AuctionStatus.LIVE,
+                    DEFAULT_START_PRICE, DEFAULT_BID_INCREMENT);
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When & Then: 11500 - 10000 = 1500, 1500 % 1000 != 0
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 11500, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.BID_INVALID_INCREMENT);
+        }
+
+        @Test
+        @DisplayName("최대 입찰가 초과면 BID_AMOUNT_EXCEEDS_LIMIT 발생")
+        void givenAmountExceedsLimit_whenCreateBid_thenThrowAmountExceedsLimit() {
+            // Given
+            Auction auction = createMockAuction(auctionId, sellerId, AuctionStatus.LIVE);
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+
+            // When & Then: MAX_BID_AMOUNT = 10,000,000
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 15_000_000, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.BID_AMOUNT_EXCEEDS_LIMIT);
+        }
+    }
+
+    @Nested
+    @DisplayName("락 획득 실패 처리")
+    class LockAcquisitionFailure {
+
+        @Test
+        @DisplayName("PessimisticLockException 발생 시 AUCTION_LOCK_BUSY")
+        void givenPessimisticLockException_whenCreateBid_thenThrowLockBusy() {
+            // Given
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenThrow(new PessimisticLockException());
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 15000, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_LOCK_BUSY);
+        }
+
+        @Test
+        @DisplayName("LockTimeoutException 발생 시 AUCTION_LOCK_BUSY")
+        void givenLockTimeoutException_whenCreateBid_thenThrowLockBusy() {
+            // Given
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenThrow(new LockTimeoutException());
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 15000, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_LOCK_BUSY);
+        }
+
+        @Test
+        @DisplayName("PessimisticLockingFailureException 발생 시 AUCTION_LOCK_BUSY")
+        void givenPessimisticLockingFailureException_whenCreateBid_thenThrowLockBusy() {
+            // Given
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenThrow(new PessimisticLockingFailureException("Lock failed"));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 15000, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_LOCK_BUSY);
+        }
+
+        @Test
+        @DisplayName("CannotAcquireLockException 발생 시 AUCTION_LOCK_BUSY")
+        void givenCannotAcquireLockException_whenCreateBid_thenThrowLockBusy() {
+            // Given
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenThrow(new CannotAcquireLockException("Lock failed"));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 15000, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_LOCK_BUSY);
+        }
+
+        @Test
+        @DisplayName("PostgreSQL 'could not obtain lock' 메시지 예외 시 AUCTION_LOCK_BUSY")
+        void givenPostgresLockMessage_whenCreateBid_thenThrowLockBusy() {
+            // Given
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenThrow(new RuntimeException("could not obtain lock on row in relation"));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, 15000, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_LOCK_BUSY);
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 입찰 처리")
+    class SuccessfulBidProcessing {
+
+        @Test
+        @DisplayName("유효한 입찰 시 Bid 저장 및 Auction currentPrice/bidCount 갱신")
+        void givenValidBid_whenCreateBid_thenSaveBidAndUpdateAuction() {
+            // Given
+            int amount = 11000; // currentPrice(10000) + increment(1000)
+            Auction auction = createMockAuction(auctionId, sellerId, AuctionStatus.LIVE);
+            User bidder = createMockUser(buyerId);
+
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+            when(bidRepository.findTopBidderIdByAuction(auction))
+                    .thenReturn(Optional.empty());
+            when(userRepository.getReferenceById(buyerId))
+                    .thenReturn(bidder);
+
+            // When
+            BidCreateResponse response = sut.createBid(auctionId, buyerId, amount, clientRequestId);
+
+            // Then
+            assertThat(response).isNotNull();
+            verify(bidRepository).saveAndFlush(any(Bid.class));
+            verify(auction).updateBid(amount);
+        }
+
+        @Test
+        @DisplayName("입찰 성공 시 bidAccepted 알림 발행")
+        void givenValidBid_whenCreateBid_thenPublishBidAcceptedNotification() {
+            // Given
+            int amount = 11000;
+            Auction auction = createMockAuction(auctionId, sellerId, AuctionStatus.LIVE);
+            User bidder = createMockUser(buyerId);
+
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+            when(bidRepository.findTopBidderIdByAuction(auction))
+                    .thenReturn(Optional.empty());
+            when(userRepository.getReferenceById(buyerId))
+                    .thenReturn(bidder);
+
+            // When
+            sut.createBid(auctionId, buyerId, amount, clientRequestId);
+
+            // Then
+            verify(notificationPublisher, atLeastOnce()).publish(any(NotificationPublishCommand.class));
+        }
+
+        @Test
+        @DisplayName("이전 최고 입찰자가 있으면 outbid 알림 발행")
+        void givenPreviousHighestBidder_whenCreateBid_thenPublishOutbidNotification() {
+            // Given
+            UUID prevBidderId = generateUserId();
+            int amount = 11000;
+            Auction auction = createMockAuction(auctionId, sellerId, AuctionStatus.LIVE);
+            User bidder = createMockUser(buyerId);
+
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+            when(bidRepository.findTopBidderIdByAuction(auction))
+                    .thenReturn(Optional.of(prevBidderId));
+            when(userRepository.getReferenceById(buyerId))
+                    .thenReturn(bidder);
+
+            // When
+            sut.createBid(auctionId, buyerId, amount, clientRequestId);
+
+            // Then: bidAccepted + outbid = 2회 호출
+            verify(notificationPublisher, times(2)).publish(any(NotificationPublishCommand.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리 (BidCommandService 레벨)")
+    class CommandServiceIdempotency {
+
+        @Test
+        @DisplayName("동일 요청이 이미 처리되었으면 기존 결과 반환")
+        void givenExistingBid_whenCreateBid_thenReturnExistingWithoutProcessing() {
+            // Given
+            int amount = 11000;
+            Auction auction = createMockAuction(auctionId, sellerId, AuctionStatus.LIVE);
+            Bid existingBid = createMockBid(auction, createMockUser(buyerId), amount, clientRequestId);
+
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.of(existingBid));
+            when(bidRepository.findTopBidderIdByAuction(auction))
+                    .thenReturn(Optional.of(buyerId));
+
+            // When
+            BidCreateResponse response = sut.createBid(auctionId, buyerId, amount, clientRequestId);
+
+            // Then
+            assertThat(response.acceptedAmount()).isEqualTo(amount);
+            verify(auctionRepository, never()).findByIdForUpdate(any());
+            verify(bidRepository, never()).saveAndFlush(any());
+        }
+
+        @Test
+        @DisplayName("동일 요청인데 금액이 다르면 CONFLICT")
+        void givenExistingBidWithDifferentAmount_whenCreateBid_thenThrowConflict() {
+            // Given
+            int originalAmount = 11000;
+            int newAmount = 12000;
+            Auction auction = createMockAuction(auctionId, sellerId, AuctionStatus.LIVE);
+            Bid existingBid = createMockBid(auction, createMockUser(buyerId), originalAmount, clientRequestId);
+
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.of(existingBid));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, buyerId, newAmount, clientRequestId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.BID_IDEMPOTENCY_CONFLICT);
+        }
+    }
+
+    @Nested
+    @DisplayName("자동 연장")
+    class AutoExtension {
+
+        @Test
+        @DisplayName("종료 5분 이하 남은 상태에서 입찰 시 연장되고 이벤트 발행")
+        void givenAuctionAboutToEnd_whenCreateBid_thenExtendAndPublishEvent() {
+            // Given
+            int amount = 11000;
+            OffsetDateTime now = OffsetDateTime.now();
+            OffsetDateTime endAt = now.plusMinutes(3); // 3분 남음 (< 5분)
+
+            Auction auction = mock(Auction.class);
+            User seller = createMockUser(sellerId);
+            User bidder = createMockUser(buyerId);
+
+            when(auction.getAuctionId()).thenReturn(auctionId);
+            when(auction.getStatus()).thenReturn(AuctionStatus.LIVE);
+            when(auction.getSeller()).thenReturn(seller);
+            when(auction.getCurrentPrice()).thenReturn(DEFAULT_START_PRICE);
+            when(auction.getBidIncrement()).thenReturn(DEFAULT_BID_INCREMENT);
+            when(auction.getEndAt()).thenReturn(endAt);
+            when(auction.getOriginalEndAt()).thenReturn(now.minusHours(1).plusHours(DEFAULT_DURATION_HOURS));
+
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(auctionRepository.findByIdForUpdate(auctionId))
+                    .thenReturn(Optional.of(auction));
+            when(bidRepository.findTopBidderIdByAuction(auction))
+                    .thenReturn(Optional.empty());
+            when(userRepository.getReferenceById(buyerId))
+                    .thenReturn(bidder);
+
+            // When
+            BidCreateResponse response = sut.createBid(auctionId, buyerId, amount, clientRequestId);
+
+            // Then
+            assertThat(response.extensionApplied()).isTrue();
+            verify(auction).extendEndTime(any(OffsetDateTime.class), anyInt());
+
+            ArgumentCaptor<AuctionEndAtChangedEvent> eventCaptor =
+                    ArgumentCaptor.forClass(AuctionEndAtChangedEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().auctionId()).isEqualTo(auctionId);
+        }
+    }
+
+    private static final class TestTransactionManager extends AbstractPlatformTransactionManager {
+
+        @Override
+        protected Object doGetTransaction() {
+            return new Object();
+        }
+
+        @Override
+        protected void doBegin(Object transaction, TransactionDefinition definition) {
+        }
+
+        @Override
+        protected void doCommit(DefaultTransactionStatus status) {
+        }
+
+        @Override
+        protected void doRollback(DefaultTransactionStatus status) {
+        }
+
+    }
+}

--- a/src/test/java/kr/eolmago/service/auction/BidConcurrencyIntegrationTest.java
+++ b/src/test/java/kr/eolmago/service/auction/BidConcurrencyIntegrationTest.java
@@ -1,0 +1,540 @@
+package kr.eolmago.service.auction;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.PersistenceContext;
+import kr.eolmago.domain.entity.auction.Auction;
+import kr.eolmago.domain.entity.auction.AuctionItem;
+import kr.eolmago.domain.entity.auction.Bid;
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.domain.entity.auction.enums.ItemCategory;
+import kr.eolmago.domain.entity.auction.enums.ItemCondition;
+import kr.eolmago.domain.entity.user.User;
+import kr.eolmago.domain.entity.user.enums.UserRole;
+import kr.eolmago.dto.api.auction.request.BidCreateRequest;
+import kr.eolmago.dto.api.auction.response.BidCreateResponse;
+import kr.eolmago.global.exception.BusinessException;
+import kr.eolmago.global.exception.ErrorCode;
+import kr.eolmago.repository.auction.AuctionItemRepository;
+import kr.eolmago.repository.auction.AuctionRepository;
+import kr.eolmago.repository.auction.BidRepository;
+import kr.eolmago.repository.user.UserRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+// 입찰 동시성 통합 테스트
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+@DisplayName("입찰 동시성 통합 테스트 (PostgreSQL Testcontainers)")
+class BidConcurrencyIntegrationTest {
+
+    private static final int CONCURRENT_REQUESTS_SINGLE_AUCTION = 100;
+    private static final int CONCURRENT_AUCTIONS_COUNT = 5;
+    private static final int CONCURRENT_REQUESTS_PER_AUCTION = 20;
+    private static final int START_PRICE = 10_000;
+    private static final int BID_INCREMENT = 1_000;
+    private static final int DURATION_HOURS = 24;
+    private static final int THREAD_POOL_SIZE = 50;
+    private static final long TIMEOUT_SECONDS = 60;
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("eolmago_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        // Redis 비활성화
+        registry.add("spring.data.redis.host", () -> "localhost");
+        registry.add("spring.data.redis.port", () -> "6379");
+    }
+
+    @Autowired
+    private BidService bidService;
+
+    @Autowired
+    private AuctionRepository auctionRepository;
+
+    @Autowired
+    private AuctionItemRepository auctionItemRepository;
+
+    @Autowired
+    private BidRepository bidRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        executor = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.shutdownNow();
+        // 테스트 데이터 정리
+        bidRepository.deleteAll();
+        auctionRepository.deleteAll();
+        auctionItemRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("단일 경매 동시 입찰")
+    class SingleAuctionConcurrentBids {
+
+        @Test
+        @DisplayName("100개 동시 입찰 시 정합성 유지")
+        void given100ConcurrentRequests_whenBid_thenMaintainConsistency() throws InterruptedException {
+            // Given: 경매 1개, 유저 100명 준비
+            User seller = createAndSaveUser();
+            Auction auction = createAndSaveLiveAuction(seller);
+            List<User> bidders = createAndSaveUsers(CONCURRENT_REQUESTS_SINGLE_AUCTION);
+
+            CountDownLatch readyLatch = new CountDownLatch(CONCURRENT_REQUESTS_SINGLE_AUCTION);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(CONCURRENT_REQUESTS_SINGLE_AUCTION);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger lockBusyCount = new AtomicInteger(0);
+            AtomicInteger invalidAmountCount = new AtomicInteger(0);
+            AtomicInteger otherErrorCount = new AtomicInteger(0);
+            ConcurrentLinkedQueue<BidResult> results = new ConcurrentLinkedQueue<>();
+
+            // When: 100개 요청을 거의 동시에 시작
+            for (int i = 0; i < CONCURRENT_REQUESTS_SINGLE_AUCTION; i++) {
+                final int bidderIndex = i;
+                final User bidder = bidders.get(i);
+                // 각 유저가 다른 금액으로 입찰 (유효한 금액들)
+                final int bidAmount = START_PRICE + BID_INCREMENT * (i + 1);
+
+                executor.submit(() -> {
+                    try {
+                        readyLatch.countDown();
+                        startLatch.await(); // 모든 스레드가 준비될 때까지 대기
+
+                        BidCreateRequest request = new BidCreateRequest(
+                                bidAmount, "req-" + bidderIndex + "-" + UUID.randomUUID()
+                        );
+                        BidCreateResponse response = bidService.createBid(
+                                auction.getAuctionId(), request, bidder.getUserId()
+                        );
+
+                        successCount.incrementAndGet();
+                        results.add(new BidResult(bidderIndex, bidAmount, true, null));
+
+                    } catch (BusinessException e) {
+                        ErrorCode code = e.getErrorCode();
+                        results.add(new BidResult(bidderIndex, bidAmount, false, code));
+
+                        if (code == ErrorCode.AUCTION_LOCK_BUSY) {
+                            lockBusyCount.incrementAndGet();
+                        } else if (code == ErrorCode.BID_INVALID_AMOUNT) {
+                            invalidAmountCount.incrementAndGet();
+                        } else {
+                            otherErrorCount.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        otherErrorCount.incrementAndGet();
+                        results.add(new BidResult(bidderIndex, bidAmount, false, null));
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+
+            // 모든 스레드가 준비되면 동시 시작
+            readyLatch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            startLatch.countDown();
+            doneLatch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            // Then: DB 상태 검증
+            Auction updatedAuction = auctionRepository.findById(auction.getAuctionId()).orElseThrow();
+            List<Bid> allBids = bidRepository.findAll().stream()
+                    .filter(b -> b.getAuction().getAuctionId().equals(auction.getAuctionId()))
+                    .toList();
+
+            // 저장된 Bid 수와 성공 카운트 일치
+            assertThat(allBids).hasSize(successCount.get());
+
+            // bidCount 정합성
+            assertThat(updatedAuction.getBidCount()).isEqualTo(successCount.get());
+
+            // currentPrice 정합성: 최고가 Bid의 amount와 일치해야 함
+            if (!allBids.isEmpty()) {
+                int maxBidAmount = allBids.stream()
+                        .mapToInt(Bid::getAmount)
+                        .max()
+                        .orElse(START_PRICE);
+                assertThat(updatedAuction.getCurrentPrice()).isEqualTo(maxBidAmount);
+            }
+
+            // 모든 Bid는 유효한 금액이어야 함
+            allBids.forEach(bid -> {
+                assertThat(bid.getAmount()).isGreaterThanOrEqualTo(START_PRICE + BID_INCREMENT);
+            });
+
+            // 테스트가 모르는 예외는 정합성 검증 대상에서 제외하지 않는다.
+            // 예상 가능한 실패는 lock busy 또는 금액 검증 실패로만 제한한다.
+            assertThat(otherErrorCount.get()).isZero();
+
+            // 실패한 요청은 성공 데이터에 영향을 주지 않아야 한다.
+            long failedRequestCount = results.stream().filter(result -> !result.success()).count();
+            assertThat(failedRequestCount).isEqualTo(lockBusyCount.get() + invalidAmountCount.get());
+
+            // 결과 로그 출력
+            System.out.println("=== 동시성 테스트 결과 ===");
+            System.out.println("총 요청: " + CONCURRENT_REQUESTS_SINGLE_AUCTION);
+            System.out.println("성공: " + successCount.get());
+            System.out.println("락 경합 실패 (AUCTION_LOCK_BUSY): " + lockBusyCount.get());
+            System.out.println("금액 검증 실패 (BID_INVALID_AMOUNT): " + invalidAmountCount.get());
+            System.out.println("기타 에러: " + otherErrorCount.get());
+            System.out.println("최종 currentPrice: " + updatedAuction.getCurrentPrice());
+            System.out.println("저장된 Bid 수: " + allBids.size());
+        }
+
+        @Test
+        @DisplayName("동일 clientRequestId 동시 요청 시 멱등성 보장")
+        void givenSameRequestIdConcurrently_whenBid_thenOnlyOneBidCreated() throws InterruptedException {
+            // Given
+            User seller = createAndSaveUser();
+            Auction auction = createAndSaveLiveAuction(seller);
+            User bidder = createAndSaveUser();
+            String sharedClientRequestId = "shared-req-" + UUID.randomUUID();
+            int bidAmount = START_PRICE + BID_INCREMENT;
+            int concurrentRequests = 10;
+
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(concurrentRequests);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger lockBusyCount = new AtomicInteger(0);
+            AtomicInteger conflictCount = new AtomicInteger(0);
+            AtomicInteger unexpectedErrorCount = new AtomicInteger(0);
+
+            // When: 같은 유저가 같은 requestId로 동시에 여러 번 요청
+            for (int i = 0; i < concurrentRequests; i++) {
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        BidCreateRequest request = new BidCreateRequest(bidAmount, sharedClientRequestId);
+                        bidService.createBid(auction.getAuctionId(), request, bidder.getUserId());
+                        successCount.incrementAndGet();
+                    } catch (BusinessException e) {
+                        if (e.getErrorCode() == ErrorCode.BID_IDEMPOTENCY_CONFLICT) {
+                            conflictCount.incrementAndGet();
+                        } else if (e.getErrorCode() == ErrorCode.AUCTION_LOCK_BUSY) {
+                            lockBusyCount.incrementAndGet();
+                        } else {
+                            unexpectedErrorCount.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        unexpectedErrorCount.incrementAndGet();
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            doneLatch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            // Then: Bid는 정확히 1개만 생성되어야 함
+            List<Bid> bids = bidRepository.findAll().stream()
+                    .filter(b -> b.getAuction().getAuctionId().equals(auction.getAuctionId()))
+                    .filter(b -> b.getBidder().getUserId().equals(bidder.getUserId()))
+                    .toList();
+
+            assertThat(bids).hasSize(1);
+            assertThat(bids.get(0).getAmount()).isEqualTo(bidAmount);
+            assertThat(bids.get(0).getClientRequestId()).isEqualTo(sharedClientRequestId);
+            assertThat(unexpectedErrorCount.get()).isZero();
+            assertThat(successCount.get() + conflictCount.get() + lockBusyCount.get()).isEqualTo(concurrentRequests);
+        }
+
+        @Test
+        @DisplayName("선행 트랜잭션이 락을 보유 중이면 후행 입찰은 AUCTION_LOCK_BUSY로 빠르게 실패")
+        void givenAuctionRowLocked_whenCreateBid_thenFailFastWithLockBusy() throws Exception {
+            // Given
+            User seller = createAndSaveUser();
+            Auction auction = createAndSaveLiveAuction(seller);
+            User bidder = createAndSaveUser();
+            UUID auctionId = auction.getAuctionId();
+
+            CountDownLatch lockAcquiredLatch = new CountDownLatch(1);
+            CountDownLatch releaseLockLatch = new CountDownLatch(1);
+            AtomicReference<Throwable> lockerError = new AtomicReference<>();
+            TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
+            Future<?> locker = executor.submit(() -> {
+                transactionTemplate.executeWithoutResult(status -> {
+                    try {
+                        entityManager.find(Auction.class, auctionId, LockModeType.PESSIMISTIC_WRITE);
+                        entityManager.flush();
+                        lockAcquiredLatch.countDown();
+                        releaseLockLatch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        lockerError.set(e);
+                    } catch (Throwable e) {
+                        lockerError.set(e);
+                    }
+                });
+            });
+
+            assertThat(lockAcquiredLatch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+
+            BidCreateRequest request = new BidCreateRequest(
+                    START_PRICE + BID_INCREMENT,
+                    "lock-busy-" + UUID.randomUUID()
+            );
+
+            long startedAt = System.nanoTime();
+
+            try {
+                // When & Then
+                assertThatThrownBy(() -> bidService.createBid(auctionId, request, bidder.getUserId()))
+                        .isInstanceOf(BusinessException.class)
+                        .extracting(e -> ((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.AUCTION_LOCK_BUSY);
+
+                long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+
+                // application-test.yml의 lock-timeout-ms가 100ms이므로 넉넉하게 2초 안에 실패해야 한다.
+                assertThat(elapsedMillis).isLessThan(2_000);
+            } finally {
+                releaseLockLatch.countDown();
+                locker.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+
+            assertThat(lockerError.get()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("다중 경매 동시 입찰")
+    class MultipleAuctionsConcurrentBids {
+
+        @Test
+        @DisplayName("5개 경매에 각 20개 동시 요청 시 각 경매별 정합성 유지")
+        void givenMultipleAuctions_whenConcurrentBids_thenEachAuctionMaintainsConsistency() throws InterruptedException {
+            // Given: 경매 5개, 경매당 유저 20명
+            User seller = createAndSaveUser();
+            List<Auction> auctions = new ArrayList<>();
+            Map<UUID, List<User>> auctionBidders = new HashMap<>();
+
+            for (int a = 0; a < CONCURRENT_AUCTIONS_COUNT; a++) {
+                Auction auction = createAndSaveLiveAuction(seller);
+                auctions.add(auction);
+                auctionBidders.put(auction.getAuctionId(), createAndSaveUsers(CONCURRENT_REQUESTS_PER_AUCTION));
+            }
+
+            int totalRequests = CONCURRENT_AUCTIONS_COUNT * CONCURRENT_REQUESTS_PER_AUCTION;
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(totalRequests);
+
+            Map<UUID, AtomicInteger> successCounts = new ConcurrentHashMap<>();
+            Map<UUID, AtomicInteger> expectedFailureCounts = new ConcurrentHashMap<>();
+            AtomicInteger unexpectedErrorCount = new AtomicInteger(0);
+            auctions.forEach(a -> {
+                successCounts.put(a.getAuctionId(), new AtomicInteger(0));
+                expectedFailureCounts.put(a.getAuctionId(), new AtomicInteger(0));
+            });
+
+            // When: 모든 경매에 동시 입찰
+            for (Auction auction : auctions) {
+                List<User> bidders = auctionBidders.get(auction.getAuctionId());
+
+                for (int i = 0; i < CONCURRENT_REQUESTS_PER_AUCTION; i++) {
+                    final User bidder = bidders.get(i);
+                    final int bidAmount = START_PRICE + BID_INCREMENT * (i + 1);
+
+                    executor.submit(() -> {
+                        try {
+                            startLatch.await();
+                            BidCreateRequest request = new BidCreateRequest(
+                                    bidAmount, "req-" + UUID.randomUUID()
+                            );
+                            bidService.createBid(auction.getAuctionId(), request, bidder.getUserId());
+                            successCounts.get(auction.getAuctionId()).incrementAndGet();
+                        } catch (BusinessException e) {
+                            if (e.getErrorCode() == ErrorCode.AUCTION_LOCK_BUSY
+                                    || e.getErrorCode() == ErrorCode.BID_INVALID_AMOUNT) {
+                                expectedFailureCounts.get(auction.getAuctionId()).incrementAndGet();
+                            } else {
+                                unexpectedErrorCount.incrementAndGet();
+                            }
+                        } catch (Exception e) {
+                            unexpectedErrorCount.incrementAndGet();
+                        } finally {
+                            doneLatch.countDown();
+                        }
+                    });
+                }
+            }
+
+            startLatch.countDown();
+            doneLatch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            // Then: 각 경매별로 정합성 검증
+            for (Auction auction : auctions) {
+                Auction updated = auctionRepository.findById(auction.getAuctionId()).orElseThrow();
+                List<Bid> bids = bidRepository.findAll().stream()
+                        .filter(b -> b.getAuction().getAuctionId().equals(auction.getAuctionId()))
+                        .toList();
+
+                int expectedSuccess = successCounts.get(auction.getAuctionId()).get();
+
+                // bidCount = 성공한 입찰 수
+                assertThat(updated.getBidCount()).isEqualTo(expectedSuccess);
+
+                // 저장된 Bid 수 = 성공 수
+                assertThat(bids).hasSize(expectedSuccess);
+
+                // currentPrice = 최고가
+                if (!bids.isEmpty()) {
+                    int maxAmount = bids.stream().mapToInt(Bid::getAmount).max().orElse(START_PRICE);
+                    assertThat(updated.getCurrentPrice()).isEqualTo(maxAmount);
+                }
+
+                System.out.println("경매 " + auction.getAuctionId() + ": 성공 " + expectedSuccess +
+                        ", 최종가 " + updated.getCurrentPrice());
+            }
+
+            // 전체 성공 수가 0이 아니어야 함
+            int totalSuccess = successCounts.values().stream().mapToInt(AtomicInteger::get).sum();
+            assertThat(totalSuccess).isGreaterThan(0);
+            assertThat(unexpectedErrorCount.get()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("자동 연장 동시성")
+    class AutoExtensionConcurrency {
+
+        @Test
+        @DisplayName("종료 5분 이내 경매에 동시 입찰 시 연장 적용")
+        void givenAuctionAboutToEnd_whenConcurrentBids_thenExtensionApplied() throws InterruptedException {
+            // Given: 3분 후 종료되는 경매
+            User seller = createAndSaveUser();
+            AuctionItem item = createAndSaveAuctionItem();
+            OffsetDateTime now = OffsetDateTime.now();
+
+            Auction auction = Auction.create(
+                    item, seller, "Ending Soon", "Test",
+                    AuctionStatus.LIVE, START_PRICE, BID_INCREMENT, DURATION_HOURS,
+                    now.minusHours(1), now.plusMinutes(3)
+            );
+            auction = auctionRepository.save(auction);
+            final UUID auctionId = auction.getAuctionId();
+            final OffsetDateTime originalEndAt = auction.getEndAt();
+
+            List<User> bidders = createAndSaveUsers(5);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(5);
+            AtomicInteger unexpectedErrorCount = new AtomicInteger(0);
+
+            // When
+            for (int i = 0; i < 5; i++) {
+                final User bidder = bidders.get(i);
+                final int amount = START_PRICE + BID_INCREMENT * (i + 1);
+
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        BidCreateRequest request = new BidCreateRequest(amount, "req-" + UUID.randomUUID());
+                        bidService.createBid(auctionId, request, bidder.getUserId());
+                    } catch (BusinessException e) {
+                        if (e.getErrorCode() != ErrorCode.AUCTION_LOCK_BUSY
+                                && e.getErrorCode() != ErrorCode.BID_INVALID_AMOUNT) {
+                            unexpectedErrorCount.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        unexpectedErrorCount.incrementAndGet();
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            doneLatch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            // Then: 연장이 적용되어 endAt이 늘어나야 함
+            Auction updated = auctionRepository.findById(auctionId).orElseThrow();
+
+            // 입찰이 하나라도 성공했다면 연장되어야 함
+            if (updated.getBidCount() > 0) {
+                assertThat(updated.getEndAt()).isAfter(originalEndAt);
+                assertThat(updated.getExtendCount()).isGreaterThan(0);
+            }
+            assertThat(unexpectedErrorCount.get()).isZero();
+        }
+    }
+
+    private User createAndSaveUser() {
+        User user = User.create(UserRole.USER);
+        return userRepository.save(user);
+    }
+
+    private List<User> createAndSaveUsers(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> createAndSaveUser())
+                .toList();
+    }
+
+    private AuctionItem createAndSaveAuctionItem() {
+        Map<String, Object> specs = new HashMap<>();
+        specs.put("brand", "Apple");
+        AuctionItem item = AuctionItem.create("iPhone 15 Pro", ItemCategory.PHONE, ItemCondition.A, specs);
+        return auctionItemRepository.save(item);
+    }
+
+    private Auction createAndSaveLiveAuction(User seller) {
+        AuctionItem item = createAndSaveAuctionItem();
+        OffsetDateTime now = OffsetDateTime.now();
+
+        Auction auction = Auction.create(
+                item, seller, "Test Auction " + UUID.randomUUID(),
+                "Test Description", AuctionStatus.LIVE,
+                START_PRICE, BID_INCREMENT, DURATION_HOURS,
+                now, now.plusHours(DURATION_HOURS)
+        );
+        return auctionRepository.save(auction);
+    }
+
+    private record BidResult(int bidderIndex, int amount, boolean success, ErrorCode errorCode) {}
+}

--- a/src/test/java/kr/eolmago/service/auction/BidServiceTest.java
+++ b/src/test/java/kr/eolmago/service/auction/BidServiceTest.java
@@ -1,0 +1,196 @@
+package kr.eolmago.service.auction;
+
+import kr.eolmago.domain.entity.auction.Auction;
+import kr.eolmago.domain.entity.auction.Bid;
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.dto.api.auction.request.BidCreateRequest;
+import kr.eolmago.dto.api.auction.response.BidCreateResponse;
+import kr.eolmago.global.exception.BusinessException;
+import kr.eolmago.global.exception.ErrorCode;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import kr.eolmago.repository.auction.BidRepository;
+import kr.eolmago.service.auction.monitoring.AuctionBidAuditLogger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static kr.eolmago.service.auction.BidTestFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+// 멱등성 처리와 BidCommandService 위임 호출 검증
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BidService 단위 테스트")
+class BidServiceTest {
+
+    @Mock
+    private BidRepository bidRepository;
+
+    @Mock
+    private BidCommandService bidCommandService;
+
+    private BidService sut;
+
+    private final UUID auctionId = generateAuctionId();
+    private final UUID buyerId = generateUserId();
+
+    @BeforeEach
+    void setUp() {
+        sut = new BidService(
+                bidRepository,
+                bidCommandService,
+                new kr.eolmago.service.auction.monitoring.BidMetricsRecorder(new SimpleMeterRegistry()),
+                new AuctionBidAuditLogger()
+        );
+    }
+
+    @Nested
+    @DisplayName("clientRequestId 검증")
+    class ClientRequestIdValidation {
+
+        @Test
+        @DisplayName("clientRequestId가 null이면 BID_IDEMPOTENCY_REQUIRED 발생")
+        void givenNullClientRequestId_whenCreateBid_thenThrowIdempotencyRequired() {
+            // Given
+            BidCreateRequest request = new BidCreateRequest(10000, null);
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, request, buyerId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.BID_IDEMPOTENCY_REQUIRED);
+
+            verifyNoInteractions(bidCommandService);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   ", "\t", "\n"})
+        @DisplayName("clientRequestId가 blank면 BID_IDEMPOTENCY_REQUIRED 발생")
+        void givenBlankClientRequestId_whenCreateBid_thenThrowIdempotencyRequired(String clientRequestId) {
+            // Given
+            BidCreateRequest request = new BidCreateRequest(10000, clientRequestId);
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, request, buyerId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.BID_IDEMPOTENCY_REQUIRED);
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class IdempotencyHandling {
+
+        @Test
+        @DisplayName("동일 clientRequestId + amount 재요청 시 기존 결과 반환, BidCommandService 호출 없음")
+        void givenSameRequestIdAndAmount_whenCreateBid_thenReturnExistingBidWithoutCallingCommand() {
+            // Given
+            String clientRequestId = generateClientRequestId();
+            int amount = 15000;
+            BidCreateRequest request = createBidRequest(amount, clientRequestId);
+
+            Auction auction = createMockAuction(auctionId, generateUserId(), AuctionStatus.LIVE);
+            Bid existingBid = createMockBid(auction, createMockUser(buyerId), amount, clientRequestId);
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.of(existingBid));
+            when(bidRepository.findTopBidderIdByAuction(auction))
+                    .thenReturn(Optional.of(buyerId));
+
+            // When
+            BidCreateResponse response = sut.createBid(auctionId, request, buyerId);
+
+            // Then
+            assertThat(response.bidId()).isEqualTo(existingBid.getBidId());
+            assertThat(response.acceptedAmount()).isEqualTo(amount);
+
+            // BidCommandService는 호출되지 않아야 함 (멱등성으로 인해 기존 결과 반환)
+            verify(bidCommandService, never()).createBid(any(), any(), anyInt(), any());
+        }
+
+        @Test
+        @DisplayName("동일 clientRequestId + 다른 amount 재요청 시 BID_IDEMPOTENCY_CONFLICT 발생")
+        void givenSameRequestIdButDifferentAmount_whenCreateBid_thenThrowIdempotencyConflict() {
+            // Given
+            String clientRequestId = generateClientRequestId();
+            int originalAmount = 15000;
+            int differentAmount = 20000;
+            BidCreateRequest request = createBidRequest(differentAmount, clientRequestId);
+
+            Auction auction = createMockAuction(auctionId, generateUserId(), AuctionStatus.LIVE);
+            Bid existingBid = createMockBid(auction, createMockUser(buyerId), originalAmount, clientRequestId);
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.of(existingBid));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, request, buyerId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.BID_IDEMPOTENCY_CONFLICT);
+
+            verify(bidCommandService, never()).createBid(any(), any(), anyInt(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("신규 입찰 처리")
+    class NewBidHandling {
+
+        @Test
+        @DisplayName("신규 요청이면 BidCommandService.createBid() 위임 호출")
+        void givenNewRequest_whenCreateBid_thenDelegateToBidCommandService() {
+            // Given
+            String clientRequestId = generateClientRequestId();
+            int amount = 15000;
+            BidCreateRequest request = createBidRequest(amount, clientRequestId);
+
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+
+            BidCreateResponse expectedResponse = createBidResponse(
+                    1L, auctionId, amount, amount, amount + DEFAULT_BID_INCREMENT, false, buyerId
+            );
+            when(bidCommandService.createBid(auctionId, buyerId, amount, clientRequestId))
+                    .thenReturn(expectedResponse);
+
+            // When
+            BidCreateResponse response = sut.createBid(auctionId, request, buyerId);
+
+            // Then
+            assertThat(response).isEqualTo(expectedResponse);
+            verify(bidCommandService).createBid(auctionId, buyerId, amount, clientRequestId);
+        }
+
+        @Test
+        @DisplayName("BidCommandService에서 예외 발생 시 그대로 전파")
+        void givenCommandServiceThrows_whenCreateBid_thenPropagateException() {
+            // Given
+            String clientRequestId = generateClientRequestId();
+            int amount = 15000;
+            BidCreateRequest request = createBidRequest(amount, clientRequestId);
+
+            when(bidRepository.findByClientRequestIdAndBidderId(clientRequestId, buyerId))
+                    .thenReturn(Optional.empty());
+            when(bidCommandService.createBid(auctionId, buyerId, amount, clientRequestId))
+                    .thenThrow(new BusinessException(ErrorCode.AUCTION_NOT_LIVE));
+
+            // When & Then
+            assertThatThrownBy(() -> sut.createBid(auctionId, request, buyerId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.AUCTION_NOT_LIVE);
+        }
+    }
+}

--- a/src/test/java/kr/eolmago/service/auction/BidTestFixture.java
+++ b/src/test/java/kr/eolmago/service/auction/BidTestFixture.java
@@ -1,0 +1,86 @@
+package kr.eolmago.service.auction;
+
+import kr.eolmago.domain.entity.auction.Auction;
+import kr.eolmago.domain.entity.auction.Bid;
+import kr.eolmago.domain.entity.auction.enums.AuctionStatus;
+import kr.eolmago.domain.entity.user.User;
+import kr.eolmago.dto.api.auction.request.BidCreateRequest;
+import kr.eolmago.dto.api.auction.response.BidCreateResponse;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BidTestFixture {
+
+    // 테스트 상수
+    public static final int DEFAULT_START_PRICE = 10_000;
+    public static final int DEFAULT_BID_INCREMENT = 1_000;
+    public static final int DEFAULT_DURATION_HOURS = 24;
+
+    private BidTestFixture() {}
+
+
+    public static User createMockUser(UUID userId) {
+        User user = mock(User.class);
+        when(user.getUserId()).thenReturn(userId);
+        return user;
+    }
+
+    public static Auction createMockAuction(UUID auctionId, UUID sellerId, AuctionStatus status) {
+        return createMockAuction(auctionId, sellerId, status, DEFAULT_START_PRICE, DEFAULT_BID_INCREMENT);
+    }
+
+    public static Auction createMockAuction(UUID auctionId, UUID sellerId, AuctionStatus status,
+                                            int currentPrice, int bidIncrement) {
+        Auction auction = mock(Auction.class);
+        User seller = createMockUser(sellerId);
+
+        when(auction.getAuctionId()).thenReturn(auctionId);
+        when(auction.getStatus()).thenReturn(status);
+        when(auction.getSeller()).thenReturn(seller);
+        when(auction.getCurrentPrice()).thenReturn(currentPrice);
+        when(auction.getBidIncrement()).thenReturn(bidIncrement);
+        when(auction.getEndAt()).thenReturn(OffsetDateTime.now().plusHours(1));
+        when(auction.getOriginalEndAt()).thenReturn(OffsetDateTime.now().plusHours(1));
+
+        return auction;
+    }
+
+    public static Bid createMockBid(Auction auction, User bidder, int amount, String clientRequestId) {
+        Bid bid = mock(Bid.class);
+        when(bid.getBidId()).thenReturn(1L);
+        when(bid.getAuction()).thenReturn(auction);
+        when(bid.getBidder()).thenReturn(bidder);
+        when(bid.getAmount()).thenReturn(amount);
+        when(bid.getClientRequestId()).thenReturn(clientRequestId);
+        return bid;
+    }
+
+    public static BidCreateRequest createBidRequest(int amount, String clientRequestId) {
+        return new BidCreateRequest(amount, clientRequestId);
+    }
+
+    public static BidCreateResponse createBidResponse(Long bidId, UUID auctionId, int amount,
+                                                       int currentHighest, int minAcceptable,
+                                                       boolean extensionApplied, UUID highestBidderId) {
+        return new BidCreateResponse(
+                bidId, auctionId, amount, currentHighest, minAcceptable,
+                OffsetDateTime.now().plusHours(1), extensionApplied, highestBidderId
+        );
+    }
+
+    public static String generateClientRequestId() {
+        return "req-" + UUID.randomUUID().toString().substring(0, 16);
+    }
+
+    public static UUID generateUserId() {
+        return UUID.randomUUID();
+    }
+
+    public static UUID generateAuctionId() {
+        return UUID.randomUUID();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,76 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+  # Redis 비활성화
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 1s
+      lettuce:
+        shutdown-timeout: 0ms
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-client-id
+            client-secret: test-client-secret
+
+jwt:
+  secret: test-secret-key-for-testing-purposes-only-minimum-256-bits-required-here
+  access-token-expiry: 3600000
+  refresh-token-expiry: 86400000
+
+# Supabase - 테스트용 더미
+supabase:
+  url: https://test.supabase.co
+  anon-key: test-anon-key
+  service-role-key: test-service-key
+  bucket: test-bucket
+
+# Coolsms - 테스트용 더미
+coolsms:
+  apiKey: test-api-key
+  secretkey: test-secret-key
+  from:
+    number: '01000000000'
+
+chat:
+  notification-bot-user-id: 00000000-0000-0000-0000-000000000001
+
+logging:
+  level:
+    root: WARN
+    kr.eolmago: INFO
+    org.hibernate.SQL: WARN
+    org.testcontainers: INFO
+
+
+auction:
+  runtime:
+    bid:
+      lock-timeout-ms: 100
+      transaction-timeout-sec: 3
+    close:
+      lock-timeout-ms: 200
+      transaction-timeout-sec: 5
+    scheduler:
+      pool-size: 2
+      thread-name-prefix: test-auction-close-
+      await-termination-sec: 5
+      sweep-delay-ms: 60000
+      sweep-batch-size: 100
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,prometheus


### PR DESCRIPTION
## 이슈 번호
- Closes #189

## 작업 개요
입찰 동시성 제어 로직이 경합 상황에서도 데이터 정합성을 유지하는지 JUnit5 기반 통합 테스트로 검증한다.
실제로 동일 경매에 여러 요청이 동시에 들어왔을 때 어떤 결과가 보장되는가"를 테스트 코드로 명확히 남긴다.

## 작업 내용
1. 동시 요청 재현용 테스트 시나리오 구성
- 다수 스레드가 동일 시점에 입찰하도록 시나리오 구성
- 동일 경매에 대한 집중 입찰 시나리오와, 여러 경매에 대한 분산 입찰 시나리오를 구분해 검증

2. 단일 경매 hotspot 시나리오 검증
- 하나의 경매에 여러 입찰 요청이 동시에 들어오는 상황 재현
- 경매 현재가가 역전되지 않는지 확인
- 입찰 이력과 최종 최고가가 일관되는지 검증
- 락 경합 시 일부 요청이 실패하더라도 정합성이 깨지지 않는지 확인

3. 멱등 요청 재전송 시나리오 검증
- 동일 `clientRequestId`로 같은 요청이 반복 전송될 때 replay 동작 확인
- 동일 `clientRequestId`로 다른 금액이 들어올 때 conflict 발생 확인
- unique 제약 충돌 상황에서도 중복 입찰이 생성되지 않는지 검증

4. 빠른 실패 정책 검증
- 선행 요청이 락을 보유 중일 때 후행 요청이 무한정 대기하지 않고 lock busy로 종료되는지 검증
- lock timeout 정책이 적용되어 요청이 예상 범위 내에서 실패하는지 확인

5. 경매 상태 검증
- 시작 전 경매에 대한 입찰 차단
- 종료된 경매에 대한 입찰 차단
- 현재가 이하 금액, 시작가 미만 금액 등 유효성 검증 실패 시 정상 예외 반환 확인

6. 테스트 결과 정합성 검증 포인트
- 최종 현재가 == 실제 최고 입찰 금액
- 최고 입찰자 == 실제 최고가 입찰자
- 중복 입찰 생성 없음
- 동일 requestId에 대한 결과 일관성 유지
- 실패한 요청이 성공 데이터에 영향을 주지 않음
